### PR TITLE
Add ability to run/exec outer/host commands.

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -50,7 +50,7 @@ jobs:
             -v $(pwd)/examples:/app/examples \
             dctest --results-file /app/examples/results.json examples /app/examples/00-intro.yaml \
             || true
-          jq '[.pass == 1, .fail == 1] | all' examples/results.json
+          jq '[.pass == 2, .fail == 1] | all' examples/results.json
 
       - name: Setup Fixtures
         if: always()

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -15,6 +15,14 @@ tests:
         repeat: { retries: 3, interval: '1s' }
 
   test-2:
+    name: Inside and outside
+    steps:
+      - exec: node1
+        run: echo 'inside node1' && hostname && pwd
+      - exec: :host
+        run: echo 'outside compose' && hostname && pwd
+
+  test-3:
     name: Failing test
     steps:
       - exec: node1
@@ -22,13 +30,13 @@ tests:
       - exec: node1
         run: echo 'This step is skipped'
 
-  test-3:
+  test-4:
     name: Skipped test (unless running with --continue-on-error)
     steps:
       - exec: node1
         run: /bin/true
 
-  test-4:
+  test-5:
     name: Test nonexistent container
     steps:
       - exec: node2


### PR DESCRIPTION
Setting the "exec" key to ":host" will cause the run command to be spawned from the current process context of dctest (i.e. outside the docker compose instance).

Refactor docker-exec to make it more generic and split out the compose-exec part that calls it. Take stdout and stderr streams in the input and use those (or if not passed in then just create PassThrough streams. In execute-step* we create streams for stdout and stderr and do the accumulation and/or verbose echo'ing of the output/error streams.

For the outer exec functionality, this adds an outer-exec function that is similar to the docker-exec function. outer-exec calls the more generic outer-spawn which is a promise-based child_process spawn wrapper.