### PR TITLE
Signals, verbose results, and misc

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -52,6 +52,18 @@ jobs:
             || true
           jq '[.pass == 2, .fail == 1] | all' examples/results.json
 
+      - name: Run Examples with --continue-on-error
+        run: |
+          # Some examples demonstate failure.
+          # Swallow exit code and check the result counts.
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v $(pwd)/examples:/app/examples \
+            dctest --continue-on-error --results-file /app/examples/results.json examples /app/examples/00-intro.yaml \
+            || true
+          jq '[.pass == 3, .fail == 3] | all' examples/results.json
+
+
       - name: Setup Fixtures
         if: always()
         run: |

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -30,6 +30,8 @@ tests:
     name: Failing due to non-zero exit code
     steps:
       - exec: node1
+        run: echo "some leading stdout"
+      - exec: node1
         run: /bin/false
       - exec: node1
         run: echo 'This step is skipped'

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -2,7 +2,7 @@ name: Example Suite
 
 tests:
 
-  test-1:
+  passing:
     name: Passing test
     steps:
       - exec: node1
@@ -14,29 +14,29 @@ tests:
           [ "${FOO}" == "bar" ]
         repeat: { retries: 3, interval: '1s' }
 
-  test-2:
-    name: Inside and outside
+  inside-outside:
+    name: Inside and outside test
     steps:
       - exec: node1
         run: echo 'inside node1' && hostname && pwd
       - exec: :host
         run: echo 'outside compose' && hostname && pwd
 
-  test-3:
-    name: Failing test
+  fail-exit-code:
+    name: Failing due to non-zero exit code
     steps:
       - exec: node1
         run: /bin/false
       - exec: node1
         run: echo 'This step is skipped'
 
-  test-4:
+  maybe-skipped:
     name: Skipped test (unless running with --continue-on-error)
     steps:
       - exec: node1
         run: /bin/true
 
-  test-5:
+  fail-nonexistent-container:
     name: Test nonexistent container
     steps:
       - exec: node2

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -30,6 +30,14 @@ tests:
       - exec: node1
         run: echo 'This step is skipped'
 
+  fail-signal:
+    name: Failing due to INT signal
+    steps:
+      - exec: :host
+        run: kill -s INT $$
+      - exec: node1
+        run: echo 'This step is skipped'
+
   maybe-skipped:
     name: Skipped test (unless running with --continue-on-error)
     steps:

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -21,6 +21,10 @@ tests:
         run: echo 'inside node1' && hostname && pwd
       - exec: :host
         run: echo 'outside compose' && hostname && pwd
+      - exec: node1
+        run: ["echo", "array", "of", "arguments"]
+      - exec: :host
+        run: ["echo", "array", "of", "arguments"]
 
   fail-exit-code:
     name: Failing due to non-zero exit code

--- a/schema.yaml
+++ b/schema.yaml
@@ -35,7 +35,10 @@ properties:
               env:  { "$ref": "#/$defs/env" }
               exec: { type: string }
               name: { type: string }
-              run:  { type: string }
+              run:
+                oneOf:
+                  - { type: string}
+                  - { type: array, items: { type: string } }
               repeat:
                 type: object
                 additionalProperties: false

--- a/src/dctest/core.cljs
+++ b/src/dctest/core.cljs
@@ -316,6 +316,8 @@ Options:
           _ (when (and quiet verbose)
               (throw (ex-info (str "--quiet and --verbose are incompatible")
                               {})))
+          _ (when (empty? test-suite)
+              (Eprintln (str "WARNING: no test-suite was specified")))
 
           suites (P/all
                    (for [path test-suite]

--- a/src/dctest/util.cljs
+++ b/src/dctest/util.cljs
@@ -19,7 +19,10 @@
 ;; General functions
 
 (defn obj->str [obj]
-  (js/JSON.stringify (clj->js obj)))
+  (js/JSON.stringify (clj->js obj)
+                     (fn [k v] (if (instance? js/Error v)
+                                 (ex-message v)
+                                 v))))
 
 (defn log [opts & args]
   (when-not (:quiet opts)


### PR DESCRIPTION
Change summary:
* Semantic names to tests
* Capture signal interrupts
* Support arrays for cmd/run
* GHA: add --continue-on-error test case
* Warn if no test-suite specified
* Rename --verbose to --verbose-commands and allow mixing with --quiet
* Keep/hoist step data (stdout, stderr, docker exec response, etc) and put in results data if --verbose-results specified