### PR TITLE
Set COMPOSE_PROJECT_NAME in default environment.

### DIFF
--- a/src/dctest/core.cljs
+++ b/src/dctest/core.cljs
@@ -321,7 +321,7 @@ Options:
 
           results (P/loop [suites suites
                            context {:docker (Docker.)
-                                    :env {}
+                                    :env {"COMPOSE_PROJECT_NAME" project}
                                     :opts {:project project
                                            :quiet quiet
                                            :verbose-commands verbose-commands}


### PR DESCRIPTION
Set the value COMPOSE_PROJECT_NAME to the project command line positional argument.  This enables other commands (such as dcmon) that may use COMPOSE_PROJECT_NAME.