### PR TITLE
Add expressions

### DIFF
--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -1,5 +1,8 @@
 name: Example Suite
 
+env:
+  BAZ: ${{ 1 + 1 }}
+
 tests:
 
   passing:
@@ -25,6 +28,28 @@ tests:
         run: ["echo", "array", "of", "arguments"]
       - exec: :host
         run: ["echo", "array", "of", "arguments"]
+
+  expressions:
+    name: Expressions test
+    env:
+      BAR: ${{ 1 + 1 }}
+    steps:
+      - exec: node1
+        run: |
+          [ "2" == "${{ 1 + 1 }}" ]
+      - exec: node1
+        run: |
+          [ "2" == "${BAR}" ]
+      - exec: node1
+        env:
+          FOO: ${{ env.BAZ }}
+        run: |
+          [ "2" == "${{ env.FOO }}" ]
+      - exec: ${{ env.CONTAINER }}
+        env:
+          CONTAINER: node1
+        run: |
+          [ "" == "${FOO}" ]
 
   fail-exit-code:
     name: Failing due to non-zero exit code

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@lonocloud/cljs-utils": "0.1.3",
         "ajv": "^8.12.0",
         "dockerode": "^3.3.1",
+        "ebnf": "1.9.1",
         "js-yaml": "^4.1.0",
         "nbb": "^1.2.179",
         "neodoc": "^2.0.2",
@@ -78,14 +79,13 @@
       }
     },
     "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/asn1.js/node_modules/bn.js": {
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/brorand": {
       "version": "1.1.0",
@@ -206,20 +206,68 @@
       }
     },
     "node_modules/browserify-sign": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
+      "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
       "dependencies": {
-        "bn.js": "^5.1.1",
-        "browserify-rsa": "^4.0.1",
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.5",
+        "hash-base": "~3.0",
         "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "parse-asn1": "^5.1.7",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
+    },
+    "node_modules/browserify-sign/node_modules/hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
@@ -486,10 +534,18 @@
         "wcwidth": "^1.0.1"
       }
     },
+    "node_modules/ebnf": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ebnf/-/ebnf-1.9.1.tgz",
+      "integrity": "sha512-uW2UKSsuty9ANJ3YByIQE4ANkD8nqUPO7r6Fwcc1ADKPe9FRdcPpMl3VEput4JSvKBJ4J86npIC2MLP0pYkCuw==",
+      "bin": {
+        "ebnf": "dist/bin.js"
+      }
+    },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
+      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -811,15 +867,31 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parse-asn1": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
-      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
+      "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
       "dependencies": {
-        "asn1.js": "^5.2.0",
-        "browserify-aes": "^1.0.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "hash-base": "~3.0",
+        "pbkdf2": "^3.1.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/parse-asn1/node_modules/hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/path-browserify": {
@@ -1384,14 +1456,13 @@
       }
     },
     "asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
+        "minimalistic-assert": "^1.0.0"
       },
       "dependencies": {
         "bn.js": {
@@ -1449,9 +1520,9 @@
       }
     },
     "bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "brorand": {
       "version": "1.1.0",
@@ -1502,19 +1573,67 @@
       }
     },
     "browserify-sign": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
+      "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
       "requires": {
-        "bn.js": "^5.1.1",
-        "browserify-rsa": "^4.0.1",
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.5",
+        "hash-base": "~3.0",
         "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "parse-asn1": "^5.1.7",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "dependencies": {
+        "hash-base": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        }
       }
     },
     "browserify-zlib": {
@@ -1736,10 +1855,15 @@
         "wcwidth": "^1.0.1"
       }
     },
+    "ebnf": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ebnf/-/ebnf-1.9.1.tgz",
+      "integrity": "sha512-uW2UKSsuty9ANJ3YByIQE4ANkD8nqUPO7r6Fwcc1ADKPe9FRdcPpMl3VEput4JSvKBJ4J86npIC2MLP0pYkCuw=="
+    },
     "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
+      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -2031,15 +2155,27 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parse-asn1": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
-      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
+      "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
       "requires": {
-        "asn1.js": "^5.2.0",
-        "browserify-aes": "^1.0.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "hash-base": "~3.0",
+        "pbkdf2": "^3.1.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "dependencies": {
+        "hash-base": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        }
       }
     },
     "path-browserify": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@lonocloud/cljs-utils": "0.1.3",
     "ajv": "^8.12.0",
     "dockerode": "^3.3.1",
+    "ebnf": "1.9.1",
     "js-yaml": "^4.1.0",
     "nbb": "^1.2.179",
     "neodoc": "^2.0.2",

--- a/src/dctest/expressions.cljs
+++ b/src/dctest/expressions.cljs
@@ -1,0 +1,161 @@
+;; Copyright (c) 2024, Viasat, Inc
+;; Licensed under EPL 2.0
+
+(ns dctest.expressions
+  (:require [cljs-bean.core :refer [->clj]]
+            [clojure.edn :as edn]
+            [clojure.pprint :refer [pprint]]
+            [clojure.string :as S]
+            ["ebnf" :as ebnf]))
+
+(def stdlib
+  {
+   ;; Test status functions
+   "always"  (constantly true)
+   "success" #(not (get-in % [:state :failed]))
+   "failure" #(boolean (get-in % [:state :failed]))
+   })
+
+;; ALL_CAPS nodes are not returned in ast
+;; See also: https://www.ietf.org/rfc/rfc4627.txt
+(def grammar
+  "
+InterpolatedText ::= ( InterpolatedExpression | PrintableChar )*
+
+InterpolatedExpression ::= BEGIN_INTERP WHITESPACE* Expression WHITESPACE* END_INTERP
+BEGIN_INTERP           ::= '${{'
+END_INTERP             ::= '}}'
+WHITESPACE             ::= [#x20#x09#x0A#x0D]+   /* Space | Tab | \\n | \\r */
+
+PrintableChar ::= #x0009 | #x000A | #x000D | [#x0020-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+
+Expression ::= BinaryExpression | UnaryExpression
+
+BinaryExpression ::= WHITESPACE* UnaryExpression WHITESPACE* BinOp WHITESPACE* Expression WHITESPACE*
+BinOp ::= '&&' | '||' | '+' | '-' | '*' | '/'
+
+UnaryExpression ::= Value | FunctionCall | MemberExpression | Identifier | ParensExpression
+ParensExpression ::= BEGIN_PAREN_EXPR Expression END_PAREN_EXPR
+BEGIN_PAREN_EXPR ::= WHITESPACE* '(' WHITESPACE*
+END_PAREN_EXPR   ::= WHITESPACE* ')' WHITESPACE*
+
+Value ::= Null | Boolean | Number | String | Array | Object
+
+Null    ::= 'null'
+Boolean ::= 'true' | 'false'
+Number  ::= '-'? ('0' | [1-9] [0-9]*) ('.' [0-9]+)? (('e' | 'E') ( '-' | '+' )? ('0' | [1-9] [0-9]*))?
+
+String             ::= DoubleQuotedString | SingleQuotedString
+SingleQuotedString ::= \"'\" (([#x20-#x26] | [#x28-#xFFFF]) | \"'\" \"'\")* \"'\"
+DoubleQuotedString ::= '\"' (([#x20-#x21] | [#x23-#x5B] | [#x5D-#xFFFF]) | #x5C (#x22 | #x5C | #x2F | #x62 | #x66 | #x6E | #x72 | #x74 | #x75 HEXDIG HEXDIG HEXDIG HEXDIG))* '\"'
+HEXDIG             ::= [a-fA-F0-9]
+
+Array       ::= BEGIN_ARRAY (Expression (SEP_ARRAY Expression)*)? END_ARRAY
+BEGIN_ARRAY ::= WHITESPACE* '[' WHITESPACE*
+END_ARRAY   ::= WHITESPACE* ']' WHITESPACE*
+SEP_ARRAY   ::= WHITESPACE* ',' WHITESPACE*
+
+Object          ::= BEGIN_OBJECT (Member (VALUE_SEPARATOR Member)*)? END_OBJECT
+Member          ::= String NAME_SEPARATOR Expression
+BEGIN_OBJECT    ::= WHITESPACE* '{' WHITESPACE*
+END_OBJECT      ::= WHITESPACE* '}' WHITESPACE*
+NAME_SEPARATOR  ::= WHITESPACE* ':' WHITESPACE*
+VALUE_SEPARATOR ::= WHITESPACE* ',' WHITESPACE*
+
+FunctionCall    ::= Identifier BEGIN_FUNC_ARGS (Expression (SEP_FUNC_ARGS Expression)*)? END_FUNC_ARGS
+BEGIN_FUNC_ARGS ::= '('
+SEP_FUNC_ARGS   ::= WHITESPACE* ',' WHITESPACE*
+END_FUNC_ARGS   ::= ')'
+
+MemberExpression ::= Identifier Property+
+Property         ::= SEP_PROP_DOT PropertyName | BEGIN_PROP_BRACK Expression END_PROP_BRACK
+PropertyName     ::= Identifier
+SEP_PROP_DOT     ::= WHITESPACE* '.' WHITESPACE*
+BEGIN_PROP_BRACK ::= WHITESPACE* '[' WHITESPACE*
+END_PROP_BRACK   ::= WHITESPACE* ']' WHITESPACE*
+
+Identifier       ::= IDENTIFIER_START IDENTIFIER_PART*
+IDENTIFIER_START ::= [a-zA-Z] | '$' | '_'
+IDENTIFIER_PART  ::= [a-zA-Z0-9] | '$' | '_'
+  ")
+
+(def parser
+  (ebnf/Grammars.W3C.Parser. grammar))
+
+(defn get-ast [text]
+  (->clj (.getAST parser text "InterpolatedText")))
+
+;; 'parent' key returned by ebnf is circular (normal pprint causes stackoverflow)
+(defn pprint-ast [ast]
+  (letfn [(remove-parent [ast]
+            (-> ast
+                (dissoc :parent)
+                (update :children #(mapv remove-parent %))))]
+    (pprint (remove-parent ast))))
+
+(defn eval-ast
+  [context ast]
+  (let [eval #(eval-ast context %) ; don't forget the context
+        {:keys [children errors text type]} ast]
+
+    (when (seq errors)
+      (throw (ex-info "Parsing errors" errors)))
+
+    (case type
+      "InterpolatedText"       (S/join "" (map eval children))
+      "InterpolatedExpression" (let [result (eval (first children))]
+                                 (if (string? result)
+                                   result
+                                   (js/JSON.stringify (clj->js result))))
+
+      "PrintableChar"    text
+      "Expression"       (eval (first (:children ast)))
+      "ParensExpression" (eval (first (:children ast)))
+
+      "UnaryExpression"  (eval (first children))
+      "BinaryExpression" (let [[a op b] children]
+                           (case (:text op)
+                             "&&" (and (eval a) (eval b))
+                             "||" (or (eval a) (eval b))
+                             "+"  (+ (eval a) (eval b))
+                             "-"  (- (eval a) (eval b))
+                             "*"  (* (eval a) (eval b))
+                             "/"  (/ (eval a) (eval b))))
+
+      "FunctionCall"     (let [[func & args] children
+                               func (get stdlib (:text func))
+                               _ (when-not func
+                                   (throw (ex-info (str "ReferenceError: " (:text func) " is not defined") {})))
+                               args (mapv eval args)]
+                           (apply func context args))
+      "MemberExpression" (let [[ident & props] children
+                               ident (eval ident)
+                               props (mapv eval props)]
+                           (get-in ident props))
+      "Property"         (eval (first children))
+      "PropertyName"     text
+      "Identifier"       (let [ident-name text
+                               context {"env" (:env context)}]
+                           (get-in context [ident-name]))
+
+      "Value"   (eval (first children))
+      "Null"    nil
+      "Number"  (edn/read-string text)
+      "Boolean" (edn/read-string text)
+
+      "String"             (eval (first children))
+      "DoubleQuotedString" (-> text
+                               (subs 1 (- (count text) 1))
+                               (S/replace "\\\"" "\""))
+      "SingleQuotedString" (-> text
+                               (subs 1 (- (count text) 1))
+                               (S/replace "''" "'"))
+
+      "Array"  (mapv eval children)
+      "Object" (into {} (map eval children))
+      "Member" (let [[k v] children]
+                 [(eval k) (eval v)]))))
+
+(defn read-eval-print
+  [context text]
+  (eval-ast context (get-ast text)))

--- a/test/dctest/expressions_test.cljs
+++ b/test/dctest/expressions_test.cljs
@@ -1,0 +1,160 @@
+(ns dctest.expressions-test
+  (:require [cljs.test :refer-macros [are deftest is testing]]
+            [dctest.expressions :as expr]))
+
+(deftest test-basic-interpolation
+  (are [expected text] (= expected (expr/read-eval-print {} text))
+       "this is true."      "this is ${{true}}."
+       "this is false."     "this is ${{false}}."
+       "before true"        "before ${{ true }}"
+       "true after"         "${{ true }} after"
+       ;; don't interpolate
+       "this is ${true}."   "this is ${true}."
+       "this is {true}."    "this is {true}."
+       "this is ${true}}."  "this is ${true}}."
+       "this is $ {true}."  "this is $ {true}."
+       "this is $ {true}}." "this is $ {true}}.")
+
+  ;; Documenting that unclosed escape sequences are currently returned as text
+  (is (= "this is ${{true}."
+         (expr/read-eval-print {} "this is ${{true}."))))
+
+
+(deftest test-literal-expressions
+  ;; roundtrip
+  (are [expr] (= expr (expr/read-eval-print {} (str "${{" expr "}}")))
+       "true"
+       "false"
+       "null"
+       "0"
+       "1"
+       "-1"
+       "[]"
+       "[1]"
+       "[1,2,3]"
+       "{}"
+       "{\"key\":\"value\"}")
+
+  ;; non-roundtrip
+  (are [expected expr] (= expected (expr/read-eval-print {} (str "${{" expr "}}")))
+       "1"             "1.0"
+       "1"             "1.0000"
+       "-1"            "-1.0"
+       "abc"           "\"abc\""
+       "ab\"c"         "\"ab\\\"c\""
+       "abc"           "'abc'"
+       "ab'c"          "'ab''c'"
+       "[]"            "[ ]"
+       "[1]"           "[ 1]"
+       "[1]"           "[1 ]"
+       "[1]"           "[  1  ]"
+       "[1,2]"         "[ 1,2  ]"
+       "[1,2]"         "[1 , 2   ]"
+       "{}"            "{ }"
+       "{\"a\":\"b\"}" "{\"a\":\"b\"}"
+       "{\"a\":\"b\"}" "{    \"a\":\"b\"    }")
+
+  ;; Maps can print either way
+  (is (contains? #{"{\"a\":\"b\",\"k\":\"v\"}"
+                   "{\"k\":\"v\",\"a\":\"b\"}"}
+                 (expr/read-eval-print {} "${{ {    \"a\":  \"b\" , \"k\"   :\"v\"  } }}")))
+
+  ;; composite
+  (is (= "[1,\"a\",{\"k\":\"v\"}]"
+         (expr/read-eval-print {} "${{ [ 1, \"a\", {\"k\":\"v\"} ]  }}"))))
+
+(deftest test-operator-expressions
+  (are [expected expr] (= expected (expr/read-eval-print {} (str "${{" expr "}}")))
+       ;; and
+       "true"  "true  && true"
+       "false" "false && true"
+       "false" "true  && false"
+       "false" "false && false"
+       "true"  "3     && true"
+       "3"     "true  && 3"
+       "true"  "\"t\" && true"
+       "t"     "true  && \"t\""
+
+       ;; or
+       "true"  "true  || true"
+       "true"  "false || true"
+       "true"  "true  || false"
+       "false" "false || false"
+       "3"     "3     || true"
+       "true"  "true  || 3"
+       "t"     "\"t\" || true"
+       "true"  "true  || \"t\""
+
+       ;; math
+       "2"  "1 + 1"
+       "0"  "1 - 1"
+       "2"  "2 * 1"
+       "2"  "4 / 2"
+
+       ;; multiple
+       "true"  "true && true && true"
+       "false" "true && true && false"
+       "true"  "true && true || false"
+       "true"  "true || true && false"
+
+       ;; parens
+       "true"  "(true)"
+       "4"     "(4)"
+       "true"  "((true))"
+       "false" "(true && false)"
+       "true"  "true && (true && true)"
+       "true"  "true && (true || false)"
+       "false" "false || (true && false)"
+
+       "true"  "(true && true) && true"
+       "true"  "true && (true) && true"
+       )
+
+  ;; composite
+  (is (= "[2]"
+         (expr/read-eval-print {} "${{ [ 1 + 1 ]  }}")))
+  (is (= "[2,{\"a\":4}]"
+         (expr/read-eval-print {} "${{ [ (1 + 1), { \"a\": (2 + 2) } ]  }}"))))
+
+
+(deftest test-functions
+  ;; Test status
+  (are [expected state] (= expected (expr/read-eval-print {:state state} "${{ always() }}"))
+       "true" {:failed false}
+       "true" {:failed true})
+
+  (are [expected state] (= expected (expr/read-eval-print {:state state} "${{ success() }}"))
+       "true"  {:failed false}
+       "false" {:failed true})
+
+  (are [expected state] (= expected (expr/read-eval-print {:state state} "${{ failure() }}"))
+       "false" {:failed false}
+       "true" {:failed true})
+
+  ;; Documenting that functions currently do not throw if given too many arguments
+  (is (= "true"
+         (expr/read-eval-print {:state {:failed true}} "${{ always(1) }}"))))
+
+
+(deftest test-identifiers
+  ;; env support
+  (are [expected text env] (= expected (expr/read-eval-print {:env env} text))
+       "{\"foo\":3}" "${{ env }}"                  {"foo" 3}
+       "3"           "${{ env.foo }}"              {"foo" 3}
+       "3"           "${{ env['foo'] }}"           {"foo" 3}
+       "3"           "${{ env[\"foo\"] }}"         {"foo" 3}
+       "null"        "${{ env.bar }}"              {"foo" 3}
+       "3"           "${{ env . foo }}"            {"foo" 3}
+       "9"           "${{ env[env.foo].baz }}"     {"foo" "bar", "bar" {"baz" 9}}
+       "9"           "${{ env [ env.foo ] .baz }}" {"foo" "bar", "bar" {"baz" 9}})
+
+  ;; Documenting that this does not currently throw a ReferenceError
+  (is (= "null"
+         (expr/read-eval-print {} "${{ baz }}"))))
+
+
+(deftest test-error-handling
+  ;; Documenting that current parser will not interpolate (nor will it error!),
+  ;; when it cannot parse the expression inside the ${{...}}.
+  (is (= "${{ [ 1 + 1 }}"
+         (expr/read-eval-print {} "${{ [ 1 + 1 }}"))))

--- a/test/runtests.cljs
+++ b/test/runtests.cljs
@@ -1,6 +1,6 @@
 (ns runtests
   (:require [cljs.test :refer-macros [run-all-tests]]
-            ;; Add test namespaces here
+            [dctest.expressions-test]
             ))
 
 (run-all-tests #"dctest\..*")


### PR DESCRIPTION
Adds initial support for expressions within `env` (values only), `exec`, and `run` strings.

GitHub Action expressions are parsed/checked at workflow load-time, whereas currently our expressions are parsed and evaluated at run-time.  More importantly, GHA considers strings like '${{ env }' or '${{ invalid expression }}' invalid and will not run the workflow, whereas we interpret any invalid expression as plain (uninterpolated) text.  This means that users won't find invalid expressions until dctest attempts to use them in some unexpected way (or perhaps, if not used, they won't be detected at all).

PRing this as-is to unblock the other expression-based features that can be developed in parallel to fixing expression error messages.