### PR TITLE
Expressions and environment context refactor

### DIFF
--- a/src/dctest/core.cljs
+++ b/src/dctest/core.cljs
@@ -139,10 +139,10 @@ Options:
           index (or index 1)
 
           ;; Interpolate step env before other keys
-          step-env (update-vals (:env step) #(expr/read-eval-print context %))
+          step-env (update-vals (:env step) #(expr/interpolate-text context %))
           context (update context :env merge step-env)
 
-          interpolate #(expr/read-eval-print context %)
+          interpolate #(expr/interpolate-text context %)
           target (interpolate target)
           command (if (string? command)
                     (interpolate command)
@@ -210,7 +210,7 @@ Options:
 
 (defn run-test [context suite test]
   (P/let [test-name (:name test)
-          test-env (update-vals (:env test) #(expr/read-eval-print context %))
+          test-env (update-vals (:env test) #(expr/interpolate-text context %))
           context (-> context
                       (assoc-in [:state :failed] false)
                       (update :env merge test-env))
@@ -225,7 +225,7 @@ Options:
 
 (defn run-suite [context suite]
   (log (:opts context) "  " (:name suite))
-  (P/let [suite-env (update-vals (:env suite) #(expr/read-eval-print context %))
+  (P/let [suite-env (update-vals (:env suite) #(expr/interpolate-text context %))
           context (update context :env merge suite-env)
           results (P/loop [tests (vals (:tests suite))
                            context context

--- a/src/dctest/core.cljs
+++ b/src/dctest/core.cljs
@@ -7,7 +7,7 @@
             [clojure.string :as S]
             [clojure.walk :refer [postwalk]]
             [dctest.expressions :as expr]
-            [dctest.util :as util :refer [obj->str log indent]]
+            [dctest.util :as util :refer [obj->str js->map log indent]]
             [promesa.core :as P]
             [viasat.retry :as retry]
             [viasat.util :refer [fatal parse-opts write-file Eprintln]]
@@ -320,6 +320,14 @@ Options:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Main
 
+(defn js-process []
+  (let [process (select-keys (js->map js/process)
+                             ["platform" "pid" "ppid" "argv"
+                              "versions" "features"])
+        env (into {} (js->map js/process.env))]
+    (merge process
+           {"env" env})))
+
 (defn -main [& argv]
   (P/let [opts (parse-opts usage (or argv #js []))
           {:keys [continue-on-error project test-suite
@@ -334,6 +342,7 @@ Options:
           results (P/loop [suites suites
                            context {:docker (Docker.)
                                     :env {"COMPOSE_PROJECT_NAME" project}
+                                    :process (js-process)
                                     :opts {:project project
                                            :quiet quiet
                                            :verbose-commands verbose-commands}

--- a/src/dctest/expressions.cljs
+++ b/src/dctest/expressions.cljs
@@ -6,6 +6,7 @@
             [clojure.edn :as edn]
             [clojure.pprint :refer [pprint]]
             [clojure.string :as S]
+            [clojure.walk :refer [stringify-keys]]
             ["ebnf" :as ebnf]))
 
 (def stdlib
@@ -135,7 +136,7 @@ IDENTIFIER_PART  ::= [a-zA-Z0-9] | '$' | '_'
       "Property"         (eval (first children))
       "PropertyName"     text
       "Identifier"       (let [ident-name text
-                               context {"env" (:env context)}]
+                               context (stringify-keys context)]
                            (get-in context [ident-name]))
 
       "Value"   (eval (first children))

--- a/src/dctest/util.cljs
+++ b/src/dctest/util.cljs
@@ -23,6 +23,8 @@
                      (fn [k v] (if (instance? js/Error v)
                                  (ex-message v)
                                  v))))
+(defn js->map [obj]
+  (into {} (map js->clj (js/Object.entries obj))))
 
 (defn log [opts & args]
   (when-not (:quiet opts)

--- a/test/dctest/expressions_test.cljs
+++ b/test/dctest/expressions_test.cljs
@@ -3,11 +3,12 @@
             [dctest.expressions :as expr]))
 
 (deftest test-basic-interpolation
-  (are [expected text] (= expected (expr/read-eval-print {} text))
+  (are [expected text] (= expected (expr/interpolate-text {} text))
        "this is true."      "this is ${{true}}."
        "this is false."     "this is ${{false}}."
        "before true"        "before ${{ true }}"
        "true after"         "${{ true }} after"
+       "true then false"    "${{ true }} then ${{ false }}"
        ;; don't interpolate
        "this is ${true}."   "this is ${true}."
        "this is {true}."    "this is {true}."
@@ -17,12 +18,12 @@
 
   ;; Documenting that unclosed escape sequences are currently returned as text
   (is (= "this is ${{true}."
-         (expr/read-eval-print {} "this is ${{true}."))))
+         (expr/interpolate-text {} "this is ${{true}."))))
 
 
-(deftest test-literal-expressions
+(deftest test-literals-interpolation
   ;; roundtrip
-  (are [expr] (= expr (expr/read-eval-print {} (str "${{" expr "}}")))
+  (are [expr] (= expr (expr/interpolate-text {} (str "${{" expr "}}")))
        "true"
        "false"
        "null"
@@ -36,7 +37,7 @@
        "{\"key\":\"value\"}")
 
   ;; non-roundtrip
-  (are [expected expr] (= expected (expr/read-eval-print {} (str "${{" expr "}}")))
+  (are [expected expr] (= expected (expr/interpolate-text {} (str "${{" expr "}}")))
        "1"             "1.0"
        "1"             "1.0000"
        "-1"            "-1.0"
@@ -57,107 +58,107 @@
   ;; Maps can print either way
   (is (contains? #{"{\"a\":\"b\",\"k\":\"v\"}"
                    "{\"k\":\"v\",\"a\":\"b\"}"}
-                 (expr/read-eval-print {} "${{ {    \"a\":  \"b\" , \"k\"   :\"v\"  } }}")))
+                 (expr/interpolate-text {} "${{ {    \"a\":  \"b\" , \"k\"   :\"v\"  } }}")))
 
   ;; composite
   (is (= "[1,\"a\",{\"k\":\"v\"}]"
-         (expr/read-eval-print {} "${{ [ 1, \"a\", {\"k\":\"v\"} ]  }}"))))
+         (expr/interpolate-text {} "${{ [ 1, \"a\", {\"k\":\"v\"} ]  }}"))))
 
 (deftest test-operator-expressions
-  (are [expected expr] (= expected (expr/read-eval-print {} (str "${{" expr "}}")))
+  (are [expected expr] (= expected (expr/read-eval {} expr))
        ;; and
-       "true"  "true  && true"
-       "false" "false && true"
-       "false" "true  && false"
-       "false" "false && false"
-       "true"  "3     && true"
-       "3"     "true  && 3"
-       "true"  "\"t\" && true"
-       "t"     "true  && \"t\""
+       true  "true  && true"
+       false "false && true"
+       false "true  && false"
+       false "false && false"
+       true  "3     && true"
+       3     "true  && 3"
+       true  "\"t\" && true"
+       "t"   "true  && \"t\""
 
        ;; or
-       "true"  "true  || true"
-       "true"  "false || true"
-       "true"  "true  || false"
-       "false" "false || false"
-       "3"     "3     || true"
-       "true"  "true  || 3"
-       "t"     "\"t\" || true"
-       "true"  "true  || \"t\""
+       true  "true  || true"
+       true  "false || true"
+       true  "true  || false"
+       false "false || false"
+       3     "3     || true"
+       true  "true  || 3"
+       "t"   "\"t\" || true"
+       true  "true  || \"t\""
 
        ;; math
-       "2"  "1 + 1"
-       "0"  "1 - 1"
-       "2"  "2 * 1"
-       "2"  "4 / 2"
+       2  "1 + 1"
+       0  "1 - 1"
+       2  "2 * 1"
+       2  "4 / 2"
 
        ;; multiple
-       "true"  "true && true && true"
-       "false" "true && true && false"
-       "true"  "true && true || false"
-       "true"  "true || true && false"
+       true  "true && true && true"
+       false "true && true && false"
+       true  "true && true || false"
+       true  "true || true && false"
 
        ;; parens
-       "true"  "(true)"
-       "4"     "(4)"
-       "true"  "((true))"
-       "false" "(true && false)"
-       "true"  "true && (true && true)"
-       "true"  "true && (true || false)"
-       "false" "false || (true && false)"
+       true  "(true)"
+       4     "(4)"
+       true  "((true))"
+       false "(true && false)"
+       true  "true && (true && true)"
+       true  "true && (true || false)"
+       false "false || (true && false)"
 
-       "true"  "(true && true) && true"
-       "true"  "true && (true) && true"
+       true  "(true && true) && true"
+       true  "true && (true) && true"
        )
 
   ;; composite
-  (is (= "[2]"
-         (expr/read-eval-print {} "${{ [ 1 + 1 ]  }}")))
-  (is (= "[2,{\"a\":4}]"
-         (expr/read-eval-print {} "${{ [ (1 + 1), { \"a\": (2 + 2) } ]  }}"))))
+  (is (= [2]
+         (expr/read-eval {} "[ 1 + 1 ]")))
+  (is (= [2,{"a" 4}]
+         (expr/read-eval {} "[ (1 + 1), { \"a\": (2 + 2) } ] "))))
 
 
 (deftest test-functions
   ;; Test status
-  (are [expected state] (= expected (expr/read-eval-print {:state state} "${{ always() }}"))
-       "true" {:failed false}
-       "true" {:failed true})
+  (are [expected state] (= expected (expr/read-eval {:state state} "always()"))
+       true {:failed false}
+       true {:failed true})
 
-  (are [expected state] (= expected (expr/read-eval-print {:state state} "${{ success() }}"))
-       "true"  {:failed false}
-       "false" {:failed true})
+  (are [expected state] (= expected (expr/read-eval {:state state} "success()"))
+       true  {:failed false}
+       false {:failed true})
 
-  (are [expected state] (= expected (expr/read-eval-print {:state state} "${{ failure() }}"))
-       "false" {:failed false}
-       "true" {:failed true})
+  (are [expected state] (= expected (expr/read-eval {:state state} "failure()"))
+       false {:failed false}
+       true {:failed true})
 
   ;; Documenting that functions currently do not throw if given too many arguments
-  (is (= "true"
-         (expr/read-eval-print {:state {:failed true}} "${{ always(1) }}"))))
+  (is (= true
+         (expr/read-eval {:state {:failed true}} "always(1)"))))
 
 
 (deftest test-identifiers
   ;; env support
-  (are [expected text env] (= expected (expr/read-eval-print {:env env} text))
-       "{\"foo\":3}" "${{ env }}"                  {"foo" 3}
-       "3"           "${{ env.foo }}"              {"foo" 3}
-       "3"           "${{ env['foo'] }}"           {"foo" 3}
-       "3"           "${{ env[\"foo\"] }}"         {"foo" 3}
-       "null"        "${{ env.bar }}"              {"foo" 3}
-       "3"           "${{ env . foo }}"            {"foo" 3}
-       "9"           "${{ env[env.foo].baz }}"     {"foo" "bar", "bar" {"baz" 9}}
-       "9"           "${{ env [ env.foo ] .baz }}" {"foo" "bar", "bar" {"baz" 9}})
+  (are [expected text env] (= expected (expr/read-eval {:env env} text))
+       {"foo" 3} "env"                  {"foo" 3}
+       3         "env.foo"              {"foo" 3}
+       3         "env['foo']"           {"foo" 3}
+       3         "env[\"foo\"]"         {"foo" 3}
+       nil       "env.bar"              {"foo" 3}
+       3         "env . foo"            {"foo" 3}
+       9         "env[env.foo].baz"     {"foo" "bar", "bar" {"baz" 9}}
+       9         "env [ env.foo ] .baz" {"foo" "bar", "bar" {"baz" 9}})
 
-  (is (= "123"
-         (expr/read-eval-print {:a {:b {:c 123}}} "${{ a.b.c }}")))
+  (is (= 123
+         (expr/read-eval {:a {:b {:c 123}}} "a.b.c")))
 
   ;; Documenting that this does not currently throw a ReferenceError
-  (is (= "null"
-         (expr/read-eval-print {} "${{ baz }}"))))
+  (is (= nil
+         (expr/read-eval {} "baz"))))
 
 
 (deftest test-error-handling
   ;; Documenting that current parser will not interpolate (nor will it error!),
   ;; when it cannot parse the expression inside the ${{...}}.
   (is (= "${{ [ 1 + 1 }}"
-         (expr/read-eval-print {} "${{ [ 1 + 1 }}"))))
+         (expr/interpolate-text {} "${{ [ 1 + 1 }}"))))

--- a/test/dctest/expressions_test.cljs
+++ b/test/dctest/expressions_test.cljs
@@ -149,7 +149,7 @@
        "9"           "${{ env [ env.foo ] .baz }}" {"foo" "bar", "bar" {"baz" 9}})
 
   (is (= "123"
-         (expr/read-eval-print {:a {:b 123}} "${{ a.b }}")))
+         (expr/read-eval-print {:a {:b {:c 123}}} "${{ a.b.c }}")))
 
   ;; Documenting that this does not currently throw a ReferenceError
   (is (= "null"

--- a/test/dctest/expressions_test.cljs
+++ b/test/dctest/expressions_test.cljs
@@ -148,6 +148,9 @@
        "9"           "${{ env[env.foo].baz }}"     {"foo" "bar", "bar" {"baz" 9}}
        "9"           "${{ env [ env.foo ] .baz }}" {"foo" "bar", "bar" {"baz" 9}})
 
+  (is (= "123"
+         (expr/read-eval-print {:a {:b 123}} "${{ a.b }}")))
+
   ;; Documenting that this does not currently throw a ReferenceError
   (is (= "null"
          (expr/read-eval-print {} "${{ baz }}"))))


### PR DESCRIPTION
* Use full context object for evaluation (not just "env" key).
* Add JS "process" subset to expression eval context.
* Separate interpolation and expression evaluation and refactor reading/printing
