### PR TITLE
Better expression errors

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -3,7 +3,7 @@ $defs:
   env:
     type: object
     propertyNames: { type: string }
-    additionalProperties: { type: string }
+    additionalProperties: { type: string, expression: InterpolatedText }
 
 # suite
 type: object
@@ -33,13 +33,13 @@ properties:
             required: [ exec, run ]
             properties:
               env:  { "$ref": "#/$defs/env" }
-              exec: { type: string }
+              exec: { type: string, expression: InterpolatedText }
               name: { type: string }
               index: { type: integer }
               run:
                 oneOf:
-                  - { type: string}
-                  - { type: array, items: { type: string } }
+                  - { type: string, expression: InterpolatedText }
+                  - { type: array, items: { type: string, expression: InterpolatedText } }
               repeat:
                 type: object
                 additionalProperties: false

--- a/test/dctest/expressions_test.cljs
+++ b/test/dctest/expressions_test.cljs
@@ -144,10 +144,15 @@
        false {:failed false}
        true {:failed true})
 
-  ;; Documenting that functions currently do not throw if given too many arguments
-  (is (= true
-         (expr/read-eval {:state {:failed true}} "always(1)"))))
+  ;; Check function names/args
+  (are [text] (thrown-with-msg? js/Error #"Unchecked errors"
+                                (expr/read-eval {:state {:failed false}} text))
+       "always(1)"
+       "foo()")
 
+  (are [text errors] (= errors (expr/flatten-errors (expr/read-ast text "Expression")))
+       "always(1)" [{:message "ArityError: incorrect number of arguments to always"}]
+       "foo()"     [{:message "ReferenceError: foo is not supported"}]))
 
 (deftest test-identifiers
   ;; env support


### PR DESCRIPTION
Add a way to catch user errors within expressions as early as possible (deferring until runtime means a long feedback cycle or possibly never finding a lurking issue).

To support checking at load time, we add a keyword 'expression' to ajv, which we can use to annotate our schema with AST node names.  For instance, when we add 'if' support, we would annotate it with 'Expression' (or perhaps a new node that means either a single interpolated expression or a naked Expression like we have, if we want to support both like GHA does).

The ebnf parser generally gives up if it cannot parse an expression as an expression, and in particular (as we've seen in our tests), unclosed or invalid InterpolatedText's are simply parsed as plain text, which defers the user mistake to runtime.  We add `check-ast` and `semantic-errors` which are called implicitly any time `read-ast` is called.  This gives us the power to add our own errors to the parse errors from ebnf (if any are present).  For instance, we use this to verify InterpolatedText nodes have the expected number of interpolated expressions, and when they don't, we have all the information necessary to narrow which expressions might be invalid (obviously could do more here in the future even).

Finally, this adds better error checking for context names and function calls.

