### PR TITLE
Refactoring and 'if' expressions

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -50,7 +50,7 @@ jobs:
             -v $(pwd)/examples:/app/examples \
             dctest --results-file /app/examples/results.json examples /app/examples/00-intro.yaml \
             || true
-          jq '[.pass == 2, .fail == 1] | all' examples/results.json
+          jq --exit-status '[.pass == 3, .fail == 1] | all' examples/results.json
 
       - name: Run Examples with --continue-on-error
         run: |
@@ -61,7 +61,7 @@ jobs:
             -v $(pwd)/examples:/app/examples \
             dctest --continue-on-error --results-file /app/examples/results.json examples /app/examples/00-intro.yaml \
             || true
-          jq '[.pass == 3, .fail == 3] | all' examples/results.json
+          jq --exit-status '[.pass == 4, .fail == 3] | all' examples/results.json
 
 
       - name: Setup Fixtures

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -23,6 +23,7 @@ tests:
       - exec: node1
         run: echo 'inside node1' && hostname && pwd
       - exec: :host
+        shell: bash
         run: echo 'outside compose' && hostname && pwd
       - exec: node1
         run: ["echo", "array", "of", "arguments"]

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -11,14 +11,17 @@ tests:
       - exec: node1
         run: /bin/true
       - exec: node1
-        if: failure()
-        run: /bin/false
-      - exec: node1
         env:
           FOO: bar
         run: |
           [ "${FOO}" == "bar" ]
         repeat: { retries: 3, interval: '1s' }
+      - exec: node1
+        if: success()
+        run: echo "This will be run!"
+      - exec: node1
+        if: failure()
+        run: echo "This will NOT be run!"
 
   inside-outside:
     name: Inside and outside test
@@ -64,6 +67,9 @@ tests:
         run: /bin/false
       - exec: node1
         run: echo 'This step is skipped'
+      - exec: node1
+        if: failure()
+        run: echo "This step WILL be run!"
 
   fail-signal:
     name: Failing due to INT signal

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -11,6 +11,9 @@ tests:
       - exec: node1
         run: /bin/true
       - exec: node1
+        if: failure()
+        run: /bin/false
+      - exec: node1
         env:
           FOO: bar
         run: |

--- a/schema.yaml
+++ b/schema.yaml
@@ -48,3 +48,4 @@ properties:
                   interval: { "$ref": "#/$defs/interval", default: "1s" }
                   retries:  { type: integer } # no default (infinite retries)
                 default: { retries: 0 } # do not retry, if repeat is missing
+              shell: { type: string, enum: ["sh", "bash"], default: "sh" }

--- a/schema.yaml
+++ b/schema.yaml
@@ -35,6 +35,7 @@ properties:
               env:  { "$ref": "#/$defs/env" }
               exec: { type: string, expression: InterpolatedText }
               name: { type: string }
+              if: { type: string, expression: Expression, default: "success()" }
               index: { type: integer }
               run:
                 oneOf:

--- a/src/dctest/core.cljs
+++ b/src/dctest/core.cljs
@@ -157,7 +157,7 @@ Options:
 (defn execute-step [context step]
   (P/let [{:keys [opts]} context
           {:keys [verbose-commands]} opts
-          skip? (get-in context [:state :failed])]
+          skip? (not (expr/read-eval context (:if step)))]
 
     (if skip?
       (let [results (merge {:outcome :skip}


### PR DESCRIPTION
The primary goal of this PR is to setup adding 'expect' assertions, adding more interpolatable keys (e.g. 'working-directory'), and adding support for step outputs.  I wanted to refactor first, but the refactoring itself is a big enough change that I wanted to have it reviewed before building on top of it.  This also adds 'if' support, which I didn't intend to add, but it fell out pretty naturally.

Goals:

* Make a single place where assertions are described (currently just "exit code is zero")
* Collect stdout and stderr on a per retry basis, so we can assert about a single retry's stdout/stderr (not full history across retries)
* Make the step interpolation and execution easier to add to and easier to follow

To accomplish these goals, I've pushed the atom-based collection of stdout/stderr down into outer-spawn and docker-exec, having both return :stdout and :stderr keys, if we still want to collect the fully history across retries.  The outer-exec and compose-exec now have the same input and output interface, and they both now take the context, interpolated step, and opts (for logging).

execute-step* and execute-step are combined with the goal of colocating and simplifying that logic.  I think this is a step forward, but it's not quite where I'd like it to be.  The main tension is caused by how we skip steps.  On one hand, we want to skip _everything_, even step env interpolation, if we are skipping.  On the other hand, it would be very nice if the idea of skipping could be folded into the logic in more of a straight-line fashion, so that we're not constructing a result in two places of that big "if/else" in execute-step.  I was considering extracting an 'interpolate-step' function that implicitly stops interpolating things if the 'if' expression is false.  I deferred that, but if that sounds reasonable, I can apply that.  Btw, I'm also tempted to push down the 'verbose-commands' logging logic into outer-exec and compose-exec, as it's a bit distracting in execute-step.  Again open to opinions/suggestions.

Finally, this adds 'if' expression support to control executing/skipping of steps.  This is subtly different than GHA in two ways that are worth mentioning:

* our 'if' must take a bare expression (ex: `env.FOO == "BAR"`) and cannot be wrapped in `${{ ... }}`
* our 'if' expressions do not implicitly add `success()`, so to replicate the GHA behavior of `env.FOO == "BAR"`, a dctest user would have to write `success() && env.FOO == "BAR"`

I think we can support the GHA 'if' behavior, if we want to change either of these decisions.  I definitely do not have strong opinion here, and in fact, I implemented what I thought you would prefer :-D (simplicity > convenience).

Other misc changes:

* Use `jq --exit-status` so our GHA workflow fails on the jq results checking steps (not sure how I missed this)
* Add 'shell' support to steps, because `hostname`/etc wasn't working on NixOS
* Changes the JSON results-file format slightly, if you were depending on it with `--verbose-results` (I am not)

(Side note:  I'm happy to squash commits.  I wanted each commit to be very clear in isolation, but I realize that may have led to more commits than we'd want.)