### PR TITLE
Support expectations

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -50,7 +50,7 @@ jobs:
             -v $(pwd)/examples:/app/examples \
             dctest --results-file /app/examples/results.json examples /app/examples/00-intro.yaml \
             || true
-          jq --exit-status '[.pass == 3, .fail == 1] | all' examples/results.json
+          jq --exit-status '[.pass == 4, .fail == 1] | all' examples/results.json
 
       - name: Run Examples with --continue-on-error
         run: |
@@ -61,7 +61,7 @@ jobs:
             -v $(pwd)/examples:/app/examples \
             dctest --continue-on-error --results-file /app/examples/results.json examples /app/examples/00-intro.yaml \
             || true
-          jq --exit-status '[.pass == 4, .fail == 3] | all' examples/results.json
+          jq --exit-status '[.pass == 5, .fail == 3] | all' examples/results.json
 
 
       - name: Setup Fixtures

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -58,6 +58,18 @@ tests:
         run: |
           [ "" == "${FOO}" ]
 
+  expect-assertions:
+    name: Expect test
+    steps:
+      - exec: node1
+        run: echo -n "2"
+        expect: step.stdout == "2"
+      - exec: node1
+        run: echo -n "3"
+        expect:
+          - step.stdout != "2"
+          - step.stdout == "3"
+
   fail-exit-code:
     name: Failing due to non-zero exit code
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dockerode": "^3.3.1",
         "ebnf": "1.9.1",
         "js-yaml": "^4.1.0",
-        "nbb": "^1.2.179",
+        "nbb": "^1.2.190",
         "neodoc": "^2.0.2",
         "shadow-cljs": "^2.28.6",
         "source-map-support": "^0.5.21"
@@ -749,9 +749,9 @@
       "optional": true
     },
     "node_modules/nbb": {
-      "version": "1.2.188",
-      "resolved": "https://registry.npmjs.org/nbb/-/nbb-1.2.188.tgz",
-      "integrity": "sha512-g8UQQEKP8ubw8UaJxJtvUekJXozHlW3b6FoUfDiqG/imaUk6xr1X5L6fl2cNHI/xgM+B/Jxy4pjaxR4KxpbLCQ==",
+      "version": "1.2.190",
+      "resolved": "https://registry.npmjs.org/nbb/-/nbb-1.2.190.tgz",
+      "integrity": "sha512-edLVjSmLDJhwkmJV4Z2k/Uw9wwSjWcZjFfMwPUkYjkznnG9KyWEaUsAf6odjyMslDCHp5hWM/ceKnoU3PpylmA==",
       "dependencies": {
         "import-meta-resolve": "^2.1.0"
       },
@@ -2041,9 +2041,9 @@
       "optional": true
     },
     "nbb": {
-      "version": "1.2.188",
-      "resolved": "https://registry.npmjs.org/nbb/-/nbb-1.2.188.tgz",
-      "integrity": "sha512-g8UQQEKP8ubw8UaJxJtvUekJXozHlW3b6FoUfDiqG/imaUk6xr1X5L6fl2cNHI/xgM+B/Jxy4pjaxR4KxpbLCQ==",
+      "version": "1.2.190",
+      "resolved": "https://registry.npmjs.org/nbb/-/nbb-1.2.190.tgz",
+      "integrity": "sha512-edLVjSmLDJhwkmJV4Z2k/Uw9wwSjWcZjFfMwPUkYjkznnG9KyWEaUsAf6odjyMslDCHp5hWM/ceKnoU3PpylmA==",
       "requires": {
         "import-meta-resolve": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dockerode": "^3.3.1",
     "ebnf": "1.9.1",
     "js-yaml": "^4.1.0",
-    "nbb": "^1.2.179",
+    "nbb": "^1.2.190",
     "neodoc": "^2.0.2",
     "shadow-cljs": "^2.28.6",
     "source-map-support": "^0.5.21"

--- a/schema.yaml
+++ b/schema.yaml
@@ -34,6 +34,10 @@ properties:
             properties:
               env:  { "$ref": "#/$defs/env" }
               exec: { type: string, expression: InterpolatedText }
+              expect:
+                oneOf:
+                  - { type: string, expression: Expression }
+                  - { type: array, items: { type: string, expression: Expression } }
               name: { type: string }
               if: { type: string, expression: Expression, default: "success()" }
               index: { type: integer }

--- a/src/dctest/core.cljs
+++ b/src/dctest/core.cljs
@@ -192,6 +192,7 @@ Options:
               interpolate #(expr/interpolate-text step-context %)
               step (-> step
                        (update :exec interpolate)
+                       (update :expect #(if (string? %) [%] %))
                        (update :index #(or % 1))
                        (update :run (fn [command]
                                       (if (string? command)
@@ -203,6 +204,14 @@ Options:
                                          retries
                                          {:delay-ms interval
                                           :check-fn #(not (:error %))})
+
+              step-context (assoc step-context :step results)
+              run-expect (fn [expr]
+                           (when-not (expr/read-eval step-context expr)
+                             {:error {:message (str "Expectation failure: " expr)}}))
+              expect-results (when-not (:error results)
+                               (first (keep run-expect (:expect step))))
+              results (merge expect-results results)
 
               outcome (if (:error results) :fail :pass)
               results (merge results

--- a/src/dctest/core.cljs
+++ b/src/dctest/core.cljs
@@ -7,7 +7,7 @@
             [clojure.string :as S]
             [clojure.walk :refer [postwalk]]
             [dctest.expressions :as expr]
-            [dctest.util :as util :refer [obj->str js->map log indent]]
+            [dctest.util :as util :refer [obj->str js->map log indent indent-print-table-str]]
             [promesa.core :as P]
             [viasat.retry :as retry]
             [viasat.util :refer [fatal parse-opts write-file Eprintln]]
@@ -208,7 +208,8 @@ Options:
               step-context (assoc step-context :step results)
               run-expect (fn [expr]
                            (when-not (expr/read-eval step-context expr)
-                             {:error {:message (str "Expectation failure: " expr)}}))
+                             {:error {:message (str "Expectation failure: " expr)
+                                      :debug (expr/explain-refs step-context expr)}}))
               expect-results (when-not (:error results)
                                (first (keep run-expect (:expect step))))
               results (merge expect-results results)
@@ -301,6 +302,15 @@ Options:
                    (map-indexed vector))]
       (log opts "  " (inc index) ")" test-name)
       (log opts "     " (:message error))
+
+      (let [columns ["reference" "value"]
+            details (:debug error)]
+        (when details
+          (log opts
+               (indent-print-table-str columns
+                                       (map #(zipmap columns %) details)
+                                       "      "))))
+
       (log opts "")))
   (log opts
        (:pass summary) "passing,"

--- a/src/dctest/expressions.cljs
+++ b/src/dctest/expressions.cljs
@@ -45,7 +45,7 @@ END_INTERP   ::= '}}'
 Expression ::= BinaryExpression | UnaryExpression
 
 BinaryExpression ::= UnaryExpression BinOp Expression
-BinOp ::= '&&' | '||' | '+' | '-' | '*' | '/'
+BinOp ::= '==' | '!=' | '&&' | '||' | '+' | '-' | '*' | '/'
 
 UnaryExpression  ::= WHITESPACE* (Value | FunctionCall | MemberExpression | ParensExpression) WHITESPACE*
 ParensExpression ::= BEGIN_PAREN_EXPR Expression END_PAREN_EXPR
@@ -210,6 +210,8 @@ ExpectedInterpolation ::= InterpolatedExpression PrintableChar*
       "UnaryExpression"  (eval (first children))
       "BinaryExpression" (let [[a op b] children]
                            (case (:text op)
+                             "==" (= (eval a) (eval b))
+                             "!=" (not= (eval a) (eval b))
                              "&&" (and (eval a) (eval b))
                              "||" (or (eval a) (eval b))
                              "+"  (+ (eval a) (eval b))

--- a/src/dctest/expressions.cljs
+++ b/src/dctest/expressions.cljs
@@ -47,7 +47,7 @@ Expression ::= BinaryExpression | UnaryExpression
 BinaryExpression ::= UnaryExpression BinOp Expression
 BinOp ::= '&&' | '||' | '+' | '-' | '*' | '/'
 
-UnaryExpression  ::= WHITESPACE* (Value | FunctionCall | MemberExpression | ContextName | ParensExpression) WHITESPACE*
+UnaryExpression  ::= WHITESPACE* (Value | FunctionCall | MemberExpression | ParensExpression) WHITESPACE*
 ParensExpression ::= BEGIN_PAREN_EXPR Expression END_PAREN_EXPR
 BEGIN_PAREN_EXPR ::= WHITESPACE* '(' WHITESPACE*
 END_PAREN_EXPR   ::= WHITESPACE* ')' WHITESPACE*
@@ -80,7 +80,7 @@ BEGIN_FUNC_ARGS ::= '('
 SEP_FUNC_ARGS   ::= WHITESPACE* ',' WHITESPACE*
 END_FUNC_ARGS   ::= ')'
 
-MemberExpression ::= ContextName Property+
+MemberExpression ::= ContextName Property*
 ContextName      ::= Identifier
 Property         ::= SEP_PROP_DOT PropertyName | BEGIN_PROP_BRACK Expression END_PROP_BRACK
 PropertyName     ::= Identifier

--- a/src/dctest/expressions.cljs
+++ b/src/dctest/expressions.cljs
@@ -13,7 +13,7 @@
 (declare read-ast)
 
 (def supported-contexts
-  #{"env" "process"})
+  #{"env" "process" "step"})
 
 (def stdlib
   {

--- a/src/dctest/util.cljs
+++ b/src/dctest/util.cljs
@@ -5,7 +5,7 @@
   (:require
     [cljs-bean.core :refer [->clj ->js]]
     [clojure.string :as S]
-    [clojure.pprint :refer [pprint]]
+    [clojure.pprint :refer [pprint print-table]]
     [dctest.expressions :as expr]
     [promesa.core :as P]
     [viasat.util :refer [Eprintln fatal read-file]]
@@ -39,10 +39,16 @@
 (defn indent [s pre]
   (-> s
       (S/replace #"[\n]*$" "")
-      (S/replace #"(^|[\n])" (str "$1" pre))))
+      (S/replace #"([\n]|^)" (str "$1" pre))))
 
 (defn indent-pprint-str [o pre]
     (indent (trim (with-out-str (pprint o))) pre))
+
+(defn indent-print-table-str
+  ([rows pre]
+   (indent (trim (with-out-str (print-table rows))) pre))
+  ([ks rows pre]
+   (indent (trim (with-out-str (print-table ks rows))) pre)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; File functions

--- a/test/dctest/expressions_test.cljs
+++ b/test/dctest/expressions_test.cljs
@@ -33,6 +33,23 @@
        "this is ${{ 1 + }}."
        "this is ${{true}} and ${{true}."))
 
+(deftest test-explain-interpolation
+  (let [context {:env {"FOO" "123"}
+                 :step {:stdout "123"
+                        :stderr "456"}}]
+    (are [expr result] (= result (expr/explain-refs context expr))
+         "1 + 1"
+         {}
+
+         "step.stdout == '987'"
+         {"step.stdout" "123"}
+
+         "step.stdout == env.FOO"
+         {"step.stdout" "123" "env.FOO" "123"}
+
+         "env"
+         {"env" {"FOO" "123"}})))
+
 (deftest test-literals-interpolation
   ;; roundtrip
   (are [expr] (= expr (expr/interpolate-text {} (str "${{" expr "}}")))

--- a/test/dctest/expressions_test.cljs
+++ b/test/dctest/expressions_test.cljs
@@ -174,10 +174,12 @@
 
   ;; Supported contexts
   (let [contexts {:env {"FOO" 1}
-                  :process {"pid" 123}}]
+                  :process {"pid" 123}
+                  :step {:code 0 :stdout "hi" :stderr ""}}]
     (are [expected text] (= expected (expr/read-eval contexts text))
-         1   "env.FOO"
-         123 "process.pid"))
+         1    "env.FOO"
+         123  "process.pid"
+         "hi" "step.stdout"))
 
   ;; Coerce keywords to strings inside context
   (is (= 123

--- a/test/dctest/expressions_test.cljs
+++ b/test/dctest/expressions_test.cljs
@@ -78,6 +78,12 @@
 
 (deftest test-operator-expressions
   (are [expected expr] (= expected (expr/read-eval {} expr))
+       ;; equality
+       true  "true == true"
+       false "true != true"
+       false "3 == 4"
+       true  "3 != 4"
+
        ;; and
        true  "true  && true"
        false "false && true"


### PR DESCRIPTION
This adds initial support for assertion expressions using the 'expect' keyword, which can be either a string expression or an array of expressions.  We also add equality operators and the 'step' context to expressions to make expectations a bit more useful.

The last commit's implementation may be smoothed out a bit more, but the goal is to give better feedback when expect expressions fail.  For instance if `step.stdout == "2"` fails, we would _really_ like to see what the value of `step.stdout` was.  We could do this with standard (separate) 'expected' and 'actual' keys, but we can also walk the AST and show the users the values of anything they reference, which is what we've done here.  Here is a sample output (pending an nbb release):

```
   Example Suite
     ✓ Passing test
     ✓ Inside and outside test
     ✓ Expressions test
     F Expect test

   1 ) Expect test
      Expectation failure: step.stdout == "2"
     |   reference | value |
     |-------------+-------|
     | step.stdout |     3 |

3 passing, 1 failed
```
