### PR TITLE
Fail steps/tests/suites when expressions throw exceptions

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Fixtures
         run: |
-          docker-compose -f examples/docker-compose.yaml up -d
+          docker compose -f examples/docker-compose.yaml up -d
 
       - name: Run Intro Examples
         run: |
@@ -78,4 +78,4 @@ jobs:
       - name: Setup Fixtures
         if: always()
         run: |
-          docker-compose -f examples/docker-compose.yaml down -t 1 --remove-orphans
+          docker compose -f examples/docker-compose.yaml down -t 1 --remove-orphans

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -50,7 +50,7 @@ jobs:
             -v $(pwd)/examples:/app/examples \
             dctest --results-file /app/examples/results.json examples /app/examples/00-intro.yaml \
             || true
-          jq --exit-status '[.pass == 4, .fail == 0] | all' examples/results.json
+          jq --exit-status '[.pass == 5, .fail == 0] | all' examples/results.json
 
       - name: Run Intro + Fail Examples with --continue-on-error
         run: |
@@ -61,7 +61,7 @@ jobs:
             -v $(pwd)/examples:/app/examples \
             dctest --continue-on-error --results-file /app/examples/results.json examples /app/examples/00-intro.yaml /app/examples/01-fails.yaml \
             || true
-          jq --exit-status '[.pass == 5, .fail == 3] | all' examples/results.json
+          jq --exit-status '[.pass == 6, .fail == 3] | all' examples/results.json
 
       - name: Run Dependency Examples
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -61,7 +61,7 @@ jobs:
             -v $(pwd)/examples:/app/examples \
             dctest --continue-on-error --results-file /app/examples/results.json examples /app/examples/00-intro.yaml /app/examples/01-fails.yaml \
             || true
-          jq --exit-status '[.pass == 6, .fail == 3] | all' examples/results.json
+          jq --exit-status '[.pass == 6, .fail == 4] | all' examples/results.json
 
       - name: Run Dependency Examples
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as build
+FROM node:16 AS build
 
 RUN apt-get -y update && \
     apt-get -y install default-jdk-headless
@@ -20,7 +20,7 @@ RUN cd /app && \
     chmod +x build/*.js
 
 
-FROM node:16-slim as run
+FROM node:16-slim AS run
 
 COPY --from=build /app/ /app/
 ADD schema.yaml /app/

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -15,7 +15,6 @@ tests:
           FOO: bar
         run: |
           [ "${FOO}" == "bar" ]
-        repeat: { retries: 3, interval: '1s' }
       - exec: node1
         if: success()
         run: echo "This will be run!"
@@ -69,3 +68,21 @@ tests:
         expect:
           - step.stdout != "2"
           - step.stdout == "3"
+
+  repeat:
+    name: Repeat test
+    steps:
+      - exec: node1
+        run: rm -f repeat-test-file
+      - exec: node1
+        repeat: { retries: 2, interval: '1s' }
+        run: |
+          if [ ! -f repeat-test-file ]; then
+            touch repeat-test-file
+          else
+            echo -n 'Repeated successfully'
+          fi
+        expect:
+          - step.stdout == "Repeated successfully"
+      - exec: node1
+        run: rm -f repeat-test-file

--- a/examples/01-fails.yaml
+++ b/examples/01-fails.yaml
@@ -34,3 +34,11 @@ tests:
     steps:
       - exec: node2
         run: /bin/true
+
+  fail-expressions:
+    name: Test thrown exception in expressions
+    steps:
+      - exec: node1
+        env:
+          FOO: ${{ throw("Intentional Failure") }}
+        run: /bin/true

--- a/schema.yaml
+++ b/schema.yaml
@@ -11,7 +11,7 @@ additionalProperties: false
 required: []
 properties:
   env:  { "$ref": "#/$defs/env" }
-  name: { type: string }
+  name: { type: string, expression: InterpolatedText }
   tests:
     type: object
     additionalProperties:
@@ -22,7 +22,7 @@ properties:
       required: []
       properties:
         env:  { "$ref": "#/$defs/env" }
-        name: { type: string }
+        name: { type: string, expression: InterpolatedText }
         depends:
           oneOf:
             - type: string
@@ -44,7 +44,7 @@ properties:
                 oneOf:
                   - { type: string, expression: Expression }
                   - { type: array, items: { type: string, expression: Expression } }
-              name: { type: string }
+              name: { type: string, expression: InterpolatedText }
               if: { type: string, expression: Expression, default: "success()" }
               index: { type: integer }
               run:

--- a/src/dctest/core.cljs
+++ b/src/dctest/core.cljs
@@ -195,8 +195,6 @@ Options:
               interpolate #(expr/interpolate-text context %)
               step (-> step
                        (update :exec interpolate)
-                       (update :expect #(if (string? %) [%] %))
-                       (update :index #(or % 1))
                        (update :run (fn [command]
                                       (if (string? command)
                                         (interpolate command)
@@ -353,14 +351,17 @@ Options:
         (* 1000))))
 
 (defn normalize [suite path]
-  (let [->step (fn [step]
+  (let [->step (fn [index step]
                  (-> step
                      (update :env update-keys name)
+                     (update :expect #(if (string? %) [%] %))
+                     (update :index #(or % 1))
+                     (update :name #(or % (str "steps[" index "]")))
                      (update-in [:repeat :interval] parse-interval)))
         ->test (fn [test id]
                  (-> (merge {:name id} test)
                      (update :env update-keys name)
-                     (update :steps #(mapv ->step %))))
+                     (update :steps #(vec (map-indexed ->step %)))))
         ->suite (fn [suite path]
                   (-> (merge {:name path} suite)
                       (update :env update-keys name)

--- a/src/dctest/expressions.cljs
+++ b/src/dctest/expressions.cljs
@@ -21,6 +21,9 @@
    "always"  {:arity 0 :fn (constantly true)}
    "success" {:arity 0 :fn #(not (get-in % [:state :failed]))}
    "failure" {:arity 0 :fn #(boolean (get-in % [:state :failed]))}
+
+   ;; Error functions
+   "throw" {:arity 1 :fn #(throw (ex-info %2 {}))}
    })
 
 (def BEGIN_INTERP "${{")

--- a/src/dctest/outcome.clj
+++ b/src/dctest/outcome.clj
@@ -1,0 +1,24 @@
+(ns dctest.outcome)
+
+;; This macros is duplicated in outcome.cljs and outcome.clj to support both
+;; ShadowCLJS and nbb. Keep in sync.
+(defmacro pending->
+  "When the suite/test/step is still pending, thread it into
+  the first form via ->. If that result is still pending, recurse
+  to the second form, etc."
+  [suite-test-or-step & forms]
+  (let [sts (gensym)
+        err (gensym)
+        forms (map (fn [f] `(try
+                              (if (dctest.outcome/pending? ~sts)
+                                (-> ~sts ~f)
+                                ~sts)
+                              (catch js/Error ~err
+                                (dctest.outcome/fail! ~sts
+                                                      {:message (str "Exception thrown: " (.-message ~err))}))))
+                   forms)]
+    `(promesa.core/let [~sts ~suite-test-or-step
+                        ~@(interleave (repeat sts) (butlast forms))]
+       ~(if (empty? forms)
+          sts
+          (last forms)))))

--- a/src/dctest/outcome.cljs
+++ b/src/dctest/outcome.cljs
@@ -1,0 +1,41 @@
+(ns dctest.outcome)
+
+(defn short-outcome [{:keys [outcome]}]
+  (get {:pass "✓" :fail "F" :skip "S"} outcome "?"))
+
+(defn failure? [{:keys [outcome]}]
+  (= :fail outcome))
+
+(defn pending? [{:keys [outcome]}]
+  (nil? outcome))
+
+(defn fail! [m & [error]]
+  (merge m
+         {:outcome :fail}
+         (when error {:error error})))
+
+(defn pass! [m] (assoc m :outcome :pass))
+(defn skip! [m] (assoc m :outcome :skip))
+
+;; This macros is duplicated in outcome.cljs and outcome.clj to support both
+;; ShadowCLJS and nbb. Keep in sync.
+(defmacro pending->
+  "When the suite/test/step is still pending, thread it into
+  the first form via ->. If that result is still pending, recurse
+  to the second form, etc."
+  [suite-test-or-step & forms]
+  (let [sts (gensym)
+        err (gensym)
+        forms (map (fn [f] `(try
+                              (if (dctest.outcome/pending? ~sts)
+                                (-> ~sts ~f)
+                                ~sts)
+                              (catch js/Error ~err
+                                (dctest.outcome/fail! ~sts
+                                                      {:message (str "Exception thrown: " (.-message ~err))}))))
+                   forms)]
+    `(promesa.core/let [~sts ~suite-test-or-step
+                        ~@(interleave (repeat sts) (butlast forms))]
+       ~(if (empty? forms)
+          sts
+          (last forms)))))


### PR DESCRIPTION
This PR conceptually adds try/catch around expressions, failing the step/test/suite if an expression throws an exception.  Also, it fixes a bug, where if an `expect` condition fails, the `run` is not retried even if `repeat` is set correctly.

Before we add catching of expression exceptions, there is a pretty substantial refactoring to move the run-(step|test|suite) functions to become "pipelines" using `->` and `while->`.  `while->` is a custom macro that takes a predicate as its first argument, then threads the initial value through functions as long as the previous initial or returned value matches the predicate.  This is used as an "early exit" mechanism, as we interpolate various parts of steps/tests/suites.

Misc:

- Dockerfile cleanup
- Verifying skipped test count in GHA when omitting `--continue-on-error`
- Interpolating step/test/suite names