### PR TITLE
Fix MemberExpression and add MethodCalls

### DIFF
--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -64,10 +64,12 @@ tests:
         run: echo -n "2"
         expect: step.stdout == "2"
       - exec: node1
-        run: echo -n "3"
+        run: |
+          echo -n '{"a": {"b": 3}, "c": "Hello World", "d": [1, 2, 3]}'
         expect:
-          - step.stdout != "2"
-          - step.stdout == "3"
+          - fromJSON(step.stdout).a.b == 3
+          - contains(fromJSON(step.stdout).c, "World")
+          - fromJSON(step.stdout).d.count() == 3
 
   repeat:
     name: Repeat test

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -3,7 +3,7 @@
                 "node_modules/@lonocloud/resolve-deps/src"]
 
  :dependencies [[funcool/promesa "8.0.450"]
-                [cljs-bean "1.8.0"]]
+                [cljs-bean "1.9.0"]]
 
  :builds
  {:dctest

--- a/src/dctest/expressions.cljs
+++ b/src/dctest/expressions.cljs
@@ -2,7 +2,7 @@
 ;; Licensed under EPL 2.0
 
 (ns dctest.expressions
-  (:require [cljs-bean.core :refer [->clj]]
+  (:require [cljs-bean.core :refer [->clj ->js]]
             [clojure.edn :as edn]
             [clojure.pprint :refer [pprint]]
             [clojure.string :as S]
@@ -17,11 +17,21 @@
   #{"env" "process" "step"})
 
 (def stdlib
+  ;; {name {:arity number :fn (fn [context & args] ..)}}
   {
    ;; Test status functions
    "always"  {:arity 0 :fn (constantly true)}
    "success" {:arity 0 :fn #(not (get-in % [:state :failed]))}
    "failure" {:arity 0 :fn #(boolean (get-in % [:state :failed]))}
+
+   ;; Conversion functions
+   "fromJSON" {:arity 1 :fn #(->clj (js/JSON.parse %2) :keywordize-keys false)}
+   "toJSON"   {:arity 1 :fn #(js/JSON.stringify (->js %2))}
+
+   ;; String functions
+   "contains"   {:arity 2 :fn #(S/includes? %2 %3)}
+   "startsWith" {:arity 2 :fn #(S/starts-with? %2 %3)}
+   "endsWith"   {:arity 2 :fn #(S/ends-with? %2 %3)}
 
    ;; Error functions
    "throw" {:arity 1 :fn #(throw (ex-info %2 {}))}

--- a/test/dctest/expressions_test.cljs
+++ b/test/dctest/expressions_test.cljs
@@ -177,7 +177,7 @@
        "always(1)" [{:message "ArityError: incorrect number of arguments to always"}]
        "foo()"     [{:message "ReferenceError: foo is not supported"}]))
 
-(deftest test-contexts
+(deftest test-member-expressions
   ;; Supported access patterns
   (are [expected text env] (= expected (expr/read-eval {:env env} text))
        {"foo" 3} "env"                  {"foo" 3}


### PR DESCRIPTION
Builds on https://github.com/Viasat/dctest/pull/15, only last 3 commits are new.

Fixes a bug in previous member access to allow things like `fromJSON(...).foo`.  Previously only `foo.a.b.c` would work, but you could not access members on values returned by functions.

Adds MethodCall to the ast to support methods like `x.toString()` and `x.count()`.

Adds some additional functions for strings and conversions.