### PR TITLE
Add --environ-file for defaults for env object

### DIFF
--- a/examples/03-env-file
+++ b/examples/03-env-file
@@ -1,0 +1,4 @@
+BAR=x
+BAR=${BAR:+c}
+BAR="b${BAR:-C}d"
+BAR="a${BAR:-SEE}e"

--- a/examples/03-env.yaml
+++ b/examples/03-env.yaml
@@ -1,0 +1,64 @@
+name: Example Suite - Environment variables
+
+# requires use of `--environ-file examples/03-env-file` to succeed
+
+env:
+  FOO: p1-${{ env.FOO || "foo" }}-s1
+  BAR: p1-${{ env.BAR || "bar" }}-s1
+
+tests:
+
+  env-depth-inside-FOO:
+    name: multiple levels, FOO inside
+    env:
+      FOO: p2-${{ env.FOO }}-s2
+    steps:
+      - exec: node1
+        env:
+          FOO: p3-${{ env.FOO }}-s3
+        run: |
+          FOO="p4-${FOO:-invaid}-s4"
+          echo "inside FOO: '${FOO}'"
+          [ "p4-p3-p2-p1-foo-s1-s2-s3-s4" = "${FOO}" ]
+
+  env-depth-inside-BAR:
+    name: multiple levels, BAR inside
+    env:
+      BAR: p2-${{ env.BAR }}-s2
+    steps:
+      - exec: node1
+        env:
+          BAR: p3-${{ env.BAR }}-s3
+        run: |
+          BAR="p4-${BAR:-invaid}-s4"
+          echo "inside BAR: '${BAR}'"
+          [ "p4-p3-p2-p1-abcde-s1-s2-s3-s4" = "${BAR}" ]
+
+  env-depth-outside-FOO:
+    name: multiple levels, FOO outside
+    env:
+      FOO: p2-${{ env.FOO }}-s2
+    steps:
+      - name: FOO outside
+        exec: :host
+        env:
+          FOO: p3-${{ env.FOO }}-s3
+        run: |
+          FOO="p4-${FOO:-invalid}-s4"
+          echo "outside FOO: '${FOO}'"
+          [ "p4-p3-p2-p1-foo-s1-s2-s3-s4" = "${FOO}" ]
+
+  env-depth-outside-BAR:
+    name: multiple levels, BAR outside
+    env:
+      FOO: p2-${{ env.FOO }}-s2
+      BAR: p2-${{ env.BAR }}-s2
+    steps:
+      - name: BAR outside
+        exec: :host
+        env:
+          BAR: p3-${{ env.BAR }}-s3
+        run: |
+          BAR="p4-${BAR:-invalid}-s4"
+          echo "outside BAR: '${BAR}'"
+          [ "p4-p3-p2-p1-abcde-s1-s2-s3-s4" = "${BAR}" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
       "version": "0.3.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@dotenvx/dotenvx": "^1.24.0",
         "@lonocloud/cljs-utils": "0.1.3",
         "@lonocloud/resolve-deps": "^0.1.0",
         "ajv": "^8.12.0",
         "dockerode": "^3.3.1",
         "ebnf": "1.9.1",
         "js-yaml": "^4.1.0",
-        "nbb": "^1.2.190",
+        "nbb": "^1.3.195",
         "neodoc": "^2.0.2",
         "shadow-cljs": "^2.28.6",
         "source-map-support": "^0.5.21"
@@ -25,6 +26,88 @@
       },
       "devDependencies": {
         "docsify-cli": "^4.4.4"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.24.0.tgz",
+      "integrity": "sha512-aL6+WyZxoPXjRaBUvNGtBRKczE6bWLKVk/s0+Hayh8pylSK0WG8fMconFLnT5KJLThSBPfa27w8UIeZX2U8K1w==",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "dotenv": "^16.4.5",
+        "eciesjs": "^0.4.10",
+        "execa": "^5.1.1",
+        "fdir": "^6.2.0",
+        "ignore": "^5.3.0",
+        "object-treeify": "1.1.33",
+        "picomatch": "^4.0.2",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "dotenvx": "src/cli/dotenvx.js",
+        "git-dotenvx": "src/cli/dotenvx.js"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/fdir": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@dotenvx/dotenvx/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@ecies/ciphers": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.1.tgz",
+      "integrity": "sha512-ezMihhjW24VNK/2qQR7lH8xCQY24nk0XHF/kwJ1OuiiY5iEwQXOcKVSy47fSoHPRG8gVGXcK5SgtONDk5xMwtQ==",
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2",
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@noble/ciphers": "^1.0.0"
       }
     },
     "node_modules/@lonocloud/cljs-utils": {
@@ -67,6 +150,42 @@
       },
       "bin": {
         "nbb": "cli.js"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.0.0.tgz",
+      "integrity": "sha512-wH5EHOmLi0rEazphPbecAzmjd12I6/Yv/SiHdkA9LSycsQk7RuuTp7am5/o62qYr0RScE7Pc9icXGBbsr6cesA==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+      "dependencies": {
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -723,6 +842,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -876,6 +1003,33 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/crypto-browserify": {
@@ -1134,6 +1288,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/duplexer3": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -1158,6 +1323,22 @@
       "integrity": "sha512-uW2UKSsuty9ANJ3YByIQE4ANkD8nqUPO7r6Fwcc1ADKPe9FRdcPpMl3VEput4JSvKBJ4J86npIC2MLP0pYkCuw==",
       "bin": {
         "ebnf": "dist/bin.js"
+      }
+    },
+    "node_modules/eciesjs": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.11.tgz",
+      "integrity": "sha512-SmUG449n1w1YGvJD9R30tBGvpxTxA0cnn0rfvpFIBvmezfIhagLjsH2JG8HBHOLS8slXsPh48II7IDUTH/J3Mg==",
+      "dependencies": {
+        "@ecies/ciphers": "^0.2.1",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0"
+      },
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2",
+        "node": ">=16"
       }
     },
     "node_modules/ee-first": {
@@ -1277,6 +1458,39 @@
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1614,6 +1828,14 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1632,6 +1854,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/import-lazy": {
       "version": "2.1.0",
@@ -1788,6 +2018,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-typedarray": {
@@ -1985,6 +2226,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -2013,6 +2259,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-response": {
@@ -2072,9 +2326,9 @@
       "optional": true
     },
     "node_modules/nbb": {
-      "version": "1.2.190",
-      "resolved": "https://registry.npmjs.org/nbb/-/nbb-1.2.190.tgz",
-      "integrity": "sha512-edLVjSmLDJhwkmJV4Z2k/Uw9wwSjWcZjFfMwPUkYjkznnG9KyWEaUsAf6odjyMslDCHp5hWM/ceKnoU3PpylmA==",
+      "version": "1.3.195",
+      "resolved": "https://registry.npmjs.org/nbb/-/nbb-1.3.195.tgz",
+      "integrity": "sha512-AMKqA+lZ/9rKpaAKarAIo+Nm/N9hRnUEQVsubgUpb0OIg0KhUFVCFUorIihr3y8vCkUSrwiR/mCuuea11XKy+Q==",
       "dependencies": {
         "import-meta-resolve": "^2.1.0"
       },
@@ -2214,12 +2468,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-treeify": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
+      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/on-finished": {
@@ -2241,6 +2514,20 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/open": {
@@ -2445,6 +2732,14 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "engines": {
         "node": ">=8"
       }
@@ -2942,11 +3237,29 @@
         "source-map": "^0.5.6"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/source-map": {
@@ -3107,6 +3420,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-indent": {
@@ -3798,6 +4119,54 @@
     }
   },
   "dependencies": {
+    "@dotenvx/dotenvx": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.24.0.tgz",
+      "integrity": "sha512-aL6+WyZxoPXjRaBUvNGtBRKczE6bWLKVk/s0+Hayh8pylSK0WG8fMconFLnT5KJLThSBPfa27w8UIeZX2U8K1w==",
+      "requires": {
+        "commander": "^11.1.0",
+        "dotenv": "^16.4.5",
+        "eciesjs": "^0.4.10",
+        "execa": "^5.1.1",
+        "fdir": "^6.2.0",
+        "ignore": "^5.3.0",
+        "object-treeify": "1.1.33",
+        "picomatch": "^4.0.2",
+        "which": "^4.0.0"
+      },
+      "dependencies": {
+        "fdir": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+          "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+          "requires": {}
+        },
+        "isexe": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+          "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="
+        },
+        "picomatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="
+        },
+        "which": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+          "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+          "requires": {
+            "isexe": "^3.1.1"
+          }
+        }
+      }
+    },
+    "@ecies/ciphers": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.1.tgz",
+      "integrity": "sha512-ezMihhjW24VNK/2qQR7lH8xCQY24nk0XHF/kwJ1OuiiY5iEwQXOcKVSy47fSoHPRG8gVGXcK5SgtONDk5xMwtQ==",
+      "requires": {}
+    },
     "@lonocloud/cljs-utils": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@lonocloud/cljs-utils/-/cljs-utils-0.1.3.tgz",
@@ -3837,6 +4206,24 @@
           }
         }
       }
+    },
+    "@noble/ciphers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.0.0.tgz",
+      "integrity": "sha512-wH5EHOmLi0rEazphPbecAzmjd12I6/Yv/SiHdkA9LSycsQk7RuuTp7am5/o62qYr0RScE7Pc9icXGBbsr6cesA=="
+    },
+    "@noble/curves": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+      "requires": {
+        "@noble/hashes": "1.5.0"
+      }
+    },
+    "@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -4349,6 +4736,11 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
+    "commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
+    },
     "configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -4480,6 +4872,26 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "crypto-browserify": {
@@ -4674,6 +5086,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
+    },
     "duplexer3": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -4693,6 +5110,17 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ebnf/-/ebnf-1.9.1.tgz",
       "integrity": "sha512-uW2UKSsuty9ANJ3YByIQE4ANkD8nqUPO7r6Fwcc1ADKPe9FRdcPpMl3VEput4JSvKBJ4J86npIC2MLP0pYkCuw=="
+    },
+    "eciesjs": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.11.tgz",
+      "integrity": "sha512-SmUG449n1w1YGvJD9R30tBGvpxTxA0cnn0rfvpFIBvmezfIhagLjsH2JG8HBHOLS8slXsPh48II7IDUTH/J3Mg==",
+      "requires": {
+        "@ecies/ciphers": "^0.2.1",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -4787,6 +5215,29 @@
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+        }
       }
     },
     "fast-deep-equal": {
@@ -5034,10 +5485,20 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -5139,6 +5600,11 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -5287,6 +5753,11 @@
       "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==",
       "dev": true
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -5308,6 +5779,11 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -5354,9 +5830,9 @@
       "optional": true
     },
     "nbb": {
-      "version": "1.2.190",
-      "resolved": "https://registry.npmjs.org/nbb/-/nbb-1.2.190.tgz",
-      "integrity": "sha512-edLVjSmLDJhwkmJV4Z2k/Uw9wwSjWcZjFfMwPUkYjkznnG9KyWEaUsAf6odjyMslDCHp5hWM/ceKnoU3PpylmA==",
+      "version": "1.3.195",
+      "resolved": "https://registry.npmjs.org/nbb/-/nbb-1.3.195.tgz",
+      "integrity": "sha512-AMKqA+lZ/9rKpaAKarAIo+Nm/N9hRnUEQVsubgUpb0OIg0KhUFVCFUorIihr3y8vCkUSrwiR/mCuuea11XKy+Q==",
       "requires": {
         "import-meta-resolve": "^2.1.0"
       }
@@ -5474,10 +5950,23 @@
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-treeify": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
+      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -5494,6 +5983,14 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
       }
     },
     "open": {
@@ -5639,6 +6136,11 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "pbkdf2": {
       "version": "3.1.2",
@@ -6016,11 +6518,23 @@
       "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz",
       "integrity": "sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA=="
     },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -6164,6 +6678,11 @@
       "requires": {
         "ansi-regex": "^5.0.1"
       }
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strip-indent": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "dctest": "./scripts/nbb-wrap"
   },
   "dependencies": {
+    "@dotenvx/dotenvx": "^1.24.0",
     "@lonocloud/cljs-utils": "0.1.3",
     "@lonocloud/resolve-deps": "^0.1.0",
     "ajv": "^8.12.0",
     "dockerode": "^3.3.1",
     "ebnf": "1.9.1",
     "js-yaml": "^4.1.0",
-    "nbb": "^1.2.190",
+    "nbb": "^1.3.195",
     "neodoc": "^2.0.2",
     "shadow-cljs": "^2.28.6",
     "source-map-support": "^0.5.21"

--- a/src/dctest/core.cljs
+++ b/src/dctest/core.cljs
@@ -37,6 +37,7 @@ Options:
   --results-file RESULTS-FILE   Write JSON results to RESULTS-FILE
   --schema-file SCHEMA          Path to input schema file [env: DCTEST_SCHEMA]
                                 [default: ./schemas/input.yaml]
+  --environ-file FILE           Load and parse FILE as default env settings.
 ")
 
 (set! *warn-on-infer* false)
@@ -538,12 +539,14 @@ Options:
 (defn -main [& argv]
   (P/let [opts (parse-opts usage (or argv #js []))
           {:keys [continue-on-error project test-suite test-filter
-                  quiet verbose-commands]} opts
+                  quiet verbose-commands environ-file]} opts
           _ (when (empty? test-suite)
               (Eprintln (str "WARNING: no test-suite was specified")))
 
+          default-env (when environ-file (util/load-env environ-file))
           context {:docker (Docker.)
-                   :env {"COMPOSE_PROJECT_NAME" project}
+                   :env (merge {"COMPOSE_PROJECT_NAME" project}
+                               default-env)
                    :process (js-process)
                    :start (js/Date.now)
                    :opts {:project project

--- a/src/dctest/util.cljs
+++ b/src/dctest/util.cljs
@@ -11,6 +11,7 @@
     [viasat.util :refer [Eprintln fatal read-file]]
     ["js-yaml" :as yaml]
     #_["ajv$default" :as Ajv]
+    ["@dotenvx/dotenvx" :as dotenvx]
     ))
 
 ;; TODO: use require syntax when shadow-cljs works with "*$default"
@@ -60,6 +61,17 @@
       (catch yaml/YAMLException err
         (Eprintln "Failure to load file:" path)
         (fatal 2 (.-message err))))))
+
+(defn load-env [path]
+  "Parse an environment file at path and do variable
+  interpolation/expansion similar to what is supported by docker
+  compose (which is a subset of posix shell variable expansion).
+  Return a map of variable names to values."
+  [path]
+  (P/let [env-raw (read-file path)
+        result (dotenvx/parse env-raw #js {:override true}) ]
+    (prn :result (js->clj result))
+    (js->clj result)))
 
 (defn ajv-error-to-str [error]
   (let [path (:instancePath error)

--- a/test/runexamples
+++ b/test/runexamples
@@ -62,6 +62,7 @@ check() {
 # TESTS
 
 copt="--continue-on-error"
+eopt="--environ-file ${repo_root}/examples/03-env-file"
 
 up
 
@@ -69,5 +70,7 @@ check 5  0 "${copt}        " 00-intro.yaml
 check 6  4 "${copt}        " 00-intro.yaml 01-fails.yaml
 check 5  1 "               " 00-intro.yaml 01-fails.yaml
 check 12 0 "${copt}        " 02-deps.yaml
+check 4  0 "${copt} ${eopt}" 03-env.yaml
+check 2  2 "${copt}        " 03-env.yaml
 
 down

--- a/test/runexamples
+++ b/test/runexamples
@@ -3,14 +3,13 @@
 PROJECT=${PROJECT:-${USER}}
 DCTEST_IMAGE=${DCTEST_IMAGE}
 
-repo_root=$(dirname $(readlink -f "${0}"))/..
-examples_dir=${repo_root}/examples
+repo_root=$(realpath $(dirname $(realpath "${0}"))/..)
 
 results_dir=$(mktemp -d)
 
-dc() { docker compose -p ${PROJECT} -f ${examples_dir}/docker-compose.yaml "${@}"; }
+dc() { docker compose -p ${PROJECT} -f ${repo_root}/examples/docker-compose.yaml "${@}"; }
 up() { dc up -d; }
-down() { dc down; }
+down() { dc down -t1; }
 
 fail() {
   msg=${1}
@@ -22,21 +21,19 @@ fail() {
 check() {
   passed=${1}; shift
   failed=${1}; shift
+  opts=${1}; shift
   example_files=${@}
 
-  if [ -z "${DCTEST_IMAGE}" ]; then
-    cmd="${repo_root}/dctest --continue-on-error --results-file ${results_dir}/results.json ${PROJECT}"
-    for example in ${example_files}; do
-      cmd="${cmd} ${examples_dir}/${example}"
-    done
-  else
+  cmd="${repo_root}/dctest"
+  if [ "${DCTEST_IMAGE}" ]; then
     cmd="docker run --rm -v /var/run/docker.sock:/var/run/docker.sock"
-    cmd="${cmd} -v ${repo_root}/examples/:/app/examples -v ${results_dir}/:/app/results"
-    cmd="${cmd} ${DCTEST_IMAGE} --continue-on-error --results-file /app/results/results.json ${PROJECT}"
-    for example in ${example_files}; do
-      cmd="${cmd} /app/examples/${example}"
-    done
+    cmd="${cmd} -v ${repo_root}/:${repo_root}:ro -v ${results_dir}/:${results_dir}"
+    cmd="${cmd} ${DCTEST_IMAGE}"
   fi
+  cmd="${cmd} ${opts} --results-file ${results_dir}/results.json ${PROJECT}"
+  for example in ${example_files}; do
+    cmd="${cmd} ${repo_root}/examples/${example}"
+  done
 
   echo "Running: ${cmd}"
   ${cmd}
@@ -59,12 +56,18 @@ check() {
 }
 
 
+[ "${repo_root}" ] || fail "repo_root cannot be empty"
+[ "/" = "${repo_root}" ] && fail "repo_root cannot be '/'"
+
 # TESTS
+
+copt="--continue-on-error"
 
 up
 
-check 5  0 00-intro.yaml
-check 6  4 00-intro.yaml 01-fails.yaml
-check 12 0 02-deps.yaml
+check 5  0 "${copt}        " 00-intro.yaml
+check 6  4 "${copt}        " 00-intro.yaml 01-fails.yaml
+check 5  1 "               " 00-intro.yaml 01-fails.yaml
+check 12 0 "${copt}        " 02-deps.yaml
 
 down


### PR DESCRIPTION
Use `--environ-file` option that parses and environment file in order to populate the base env object/map.

This uses version 1.24.0 of dotenvx (PR adding necessary functionality: https://github.com/dotenvx/dotenvx/issues/445)

Closely related to https://github.com/LonoCloud/conlink/pull/32