### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,36 +10,32 @@ on:
 
 jobs:
 
-  cljs-tests:
-    name: Run CLJS tests
+  test-node:
+    name: Run Tests+Examples (Node ${{ matrix.node_version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version: [ '16.x', '18.x', '20.x', '22.x' ]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with: { submodules: 'recursive', fetch-depth: 0 }
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node_version }}
       - name: Install NPM
         run: npm install
 
       - name: Run Tests
         run: ./test/runtests
 
-  test-examples-node:
-    name: Test Examples (Node)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with: { submodules: 'recursive', fetch-depth: 0 }
-
-      - name: Install NPM
-        run: npm install
-
       - name: Run Examples
         run: ./test/runexamples
 
-  test-examples:
-    name: Test Examples (Docker)
+  test-docker:
+    name: Run Examples (Docker)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -53,3 +53,79 @@ jobs:
         env:
           DCTEST_IMAGE: dctest
         run: ./test/runexamples
+
+  # Decide if a release is necessary, do any release linting/checks
+  check-release:
+    needs: [ test-node, test-docker ]
+    name: Check Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')
+    outputs:
+      RELEASE_VERSION: ${{ steps.get-version.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with: { submodules: 'recursive', fetch-depth: 0 }
+
+      - id: get-version
+        name: Get release version
+        run: |
+          echo "RELEASE_VERSION=$(jq -r .version package.json)" | tee "$GITHUB_ENV" | tee "$GITHUB_OUTPUT"
+
+      - name: Check git tag matches release version
+        run: |
+          [ "refs/tags/v${RELEASE_VERSION}" == "${{ github.ref }}" ]
+
+  release-npm:
+    needs: [ check-release ]
+    name: Release NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with: { submodules: 'recursive', fetch-depth: 0 }
+
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@lonocloud'
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  release-docker-hub:
+    needs: [ check-release ]
+    name: Release Docker Hub
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.check-release.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with: { submodules: 'recursive', fetch-depth: 0 }
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: lonocloud/dctest:${{ env.RELEASE_VERSION }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: lonocloud/dctest:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 AS build
+FROM node:20 AS build
 
 RUN apt-get -y update && \
     apt-get -y install default-jdk-headless
@@ -20,7 +20,7 @@ RUN cd /app && \
     chmod +x build/*.js
 
 
-FROM node:16-slim AS run
+FROM node:20-slim AS run
 
 COPY --from=build /app/ /app/
 ADD schemas/ /app/schemas/


### PR DESCRIPTION
These changes will automatically do NPM and Docker Hub releases, when we push a git tag of the form 'vX.Y.Z'.  Before we release, we run all tests and verify the git tag matches our package.json.

The "release-(npm|docker-hub)" jobs are gated by a "check-release" job, which is where we sanity test the package.json version and could do other linting/checks in the future.

I've added the necessary secrets to this repo.  I've verified the [tag check works](https://github.com/Viasat/dctest/actions/runs/11960079284) and that [the release jobs can work](https://github.com/Viasat/dctest/actions/runs/11959813518). Other than updating a couple docker actions's versions to remove the GHA node 16 warning, I believe the only thing I haven't tested is the actual publishing of artifacts (commented out in the last commit).

If this looks good, I'll remove the last commit, merge, and push a commit+tag to release 0.4.0 w/ CHANGELOG updates.