### PR TITLE
More negative test cases

### DIFF
--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -76,7 +76,21 @@ tests:
     steps:
       - exec: node1
         run: rm -f repeat-test-file
+
+      - name: Repeat on non-zero exit code
+        exec: node1
+        repeat: { retries: 2, interval: '1s' }
+        run: |
+          if [ ! -f repeat-test-file ]; then
+            touch repeat-test-file
+            exit 1
+          fi
+
       - exec: node1
+        run: rm -f repeat-test-file
+
+      - name: Repeat on failed expect assertion
+        exec: node1
         repeat: { retries: 2, interval: '1s' }
         run: |
           if [ ! -f repeat-test-file ]; then
@@ -86,5 +100,6 @@ tests:
           fi
         expect:
           - step.stdout == "Repeated successfully"
+
       - exec: node1
         run: rm -f repeat-test-file

--- a/examples/01-fails.yaml
+++ b/examples/01-fails.yaml
@@ -35,6 +35,14 @@ tests:
       - exec: node2
         run: /bin/true
 
+  fail-expect:
+    name: Failing due to unmet expect condition
+    steps:
+      - exec: node1
+        run: /bin/true
+        expect:
+          - 1 == 2
+
   fail-expressions:
     name: Test thrown exception in expressions
     steps:

--- a/examples/01-fails.yaml
+++ b/examples/01-fails.yaml
@@ -24,6 +24,7 @@ tests:
         run: echo 'This step is skipped'
 
   maybe-skipped:
+    depends: "fail-signal" # any failing test would do
     name: Skipped test (unless running with --continue-on-error)
     steps:
       - exec: node1

--- a/examples/01-fails.yaml
+++ b/examples/01-fails.yaml
@@ -44,10 +44,24 @@ tests:
         expect:
           - 1 == 2
 
-  fail-expressions:
-    name: Test thrown exception in expressions
+  fail-if-throws:
+    name: Test thrown exception in expressions ('if')
+    steps:
+      - if: throw("Intentional Failure")
+        exec: node1
+        run: /bin/true
+
+  fail-env-throws:
+    name: Test thrown exception in expressions ('env')
+    steps:
+      - env:
+          FOO: ${{ throw("Intentional Failure") }}
+        exec: node1
+        run: /bin/true
+
+  fail-expect-throws:
+    name: Test thrown exception in expressions ('expect')
     steps:
       - exec: node1
-        env:
-          FOO: ${{ throw("Intentional Failure") }}
         run: /bin/true
+        expect: throw("Intentional Failure")

--- a/test/runexamples
+++ b/test/runexamples
@@ -67,7 +67,7 @@ eopt="--environ-file ${repo_root}/examples/03-env-file"
 up
 
 check 5  0 "${copt}        " 00-intro.yaml
-check 6  4 "${copt}        " 00-intro.yaml 01-fails.yaml
+check 6  5 "${copt}        " 00-intro.yaml 01-fails.yaml
 check 5  1 "               " 00-intro.yaml 01-fails.yaml
 check 12 0 "${copt}        " 02-deps.yaml
 check 4  0 "${copt} ${eopt}" 03-env.yaml

--- a/test/runexamples
+++ b/test/runexamples
@@ -67,7 +67,7 @@ eopt="--environ-file ${repo_root}/examples/03-env-file"
 up
 
 check 5  0 "${copt}        " 00-intro.yaml
-check 6  5 "${copt}        " 00-intro.yaml 01-fails.yaml
+check 6  7 "${copt}        " 00-intro.yaml 01-fails.yaml
 check 5  1 "               " 00-intro.yaml 01-fails.yaml
 check 12 0 "${copt}        " 02-deps.yaml
 check 4  0 "${copt} ${eopt}" 03-env.yaml


### PR DESCRIPTION
This adds some missing test cases to support future refactoring/simplification of the control flow and exception handling.

I've also added a 'depends' to the 'maybe-skipped' example. While the total passed/failed counts have been reliable, my understanding is that test ordering is not actually guaranteed without 'depends'.