### PR TITLE
Test and Step Outputs

### DIFF
--- a/docs/reference/latest/expressions.md
+++ b/docs/reference/latest/expressions.md
@@ -79,6 +79,25 @@ The `step` context references the step itself and contains the following:
 | `step.stdout` | string | standard output of the command, only available after command is run |
 | `step.stderr` | string | standard error of the command, only available after command is run |
 
+### steps
+
+The `steps` context is a mapping of preceeding steps, indexed by `id`, in the
+current test. `steps` contains all the information from the `step` plus the
+following:
+
+| name | type | description |
+| ---- | ---- | ----------- |
+| `steps.<step-id>.outputs` | object | resolved `outputs` mappings |
+
+### tests
+
+The `tests` context is a mapping of preceeding tests, indexed by `id`, which
+includes the following information:
+
+| name | type | description |
+| ---- | ---- | ----------- |
+| `tests.<test-id>.outputs` | object | resolved `outputs` mappings |
+
 ## Functions and Methods
 
 ### Status

--- a/docs/reference/latest/input.md
+++ b/docs/reference/latest/input.md
@@ -22,9 +22,11 @@ Any type clarifications can be found in the glossary at the bottom.
 | `env` | map(str, istr) | set environment variables for all steps in the test, shadows suite `env` | `{}` |
 | `depends` | str or list(str) | test(s) by id that should be run before this test | `[]` |
 | `name` | istr | a human-readable test name | test id |
+| `outputs` | map(str, istr) | accessible to future tests via `tests` context; interpolated after steps | `{}` |
 | `steps` | list(step) | steps to be run | `[]` |
 
 > NOTE: `env` values are interpolated first and available to all other keys.
+> NOTE: `outputs` will always be interpolated, even if the test has failed.
 
 ## Step
 
@@ -33,9 +35,11 @@ Any type clarifications can be found in the glossary at the bottom.
 | `env` | map(str, istr) | set environment variables for command and expressions in the step, shadows suite and test `env` | `{}` |
 | `exec` | istr | location to execute `run` command, either a Docker Compose service name or `:host` | **required** |
 | `expect` | expr or list(expr) | additional success conditions, evaluated after `run` command, all of which must return a truthy value | `[]` |
+| `id` | str | identifier for the step, referenced in `steps` context | |
 | `if` | expr | execute the step, when result is truthy; otherwise, skip | `success()` |
 | `index` | int | references the index of the container to execute `run` commmand | `1` |
 | `name` | istr | a human-readable step name | step index |
+| `outputs` | map(str, istr) | accessible to future steps via `steps` context; interpolated after `run` | `{}` |
 | `repeat` | map(str, any) | presence indicates a step should be retried if the `run` or any `expect` condition fails | `null` |
 | `repeat.interval` | str | time to wait between retries in Docker Compose healthcheck format, ex: `1m20s` | `1s` |
 | `repeat.retries` | int | indicates number of retry attempts; retry indefinitely, if omitted | `null` |
@@ -44,6 +48,8 @@ Any type clarifications can be found in the glossary at the bottom.
 
 > NOTE: `if` is evaluated before `env`. When `if` is truthy, `env`
         values are interpolated and available to all other keys.
+> NOTE: Unless step is skipped entirely using `if`, `outputs` will
+        be always interpolated, even if the step has failed.
 
 ## Glossary
 

--- a/docs/reference/latest/results-file.md
+++ b/docs/reference/latest/results-file.md
@@ -31,7 +31,8 @@ top-level keys, which are further described below:
 | `id` | string | the test id (may not be unique if more than one suite was used) |
 | `name` | string | the test name |
 | `outcome` | string | the overall outcome of the test, either `passed` or `failed` |
-| `error` | string | an error message, if the test errored |
+| `error` | error | the primary/first error that occurred, if the test failed for any reason |
+| `additionalErrors` | array(error) | additional errors, if necessary |
 | `start` | integer | starting timestamp of the test (milliseconds elapsed since the epoch) |
 | `stop` | integer | ending timestamp of the test (milliseconds elapsed since the epoch) |
 | `steps` | array(step) | steps executed during this test |
@@ -42,7 +43,8 @@ Where steps contain the following keys:
 | ---- | ---- | ----------- |
 | `name` | string | the step name |
 | `outcome` | string | the overall outcome of the test, one of `passed`, `failed`, or `skipped` |
-| `error` | string | an error message, if the step failed for any reason |
+| `error` | error | the primary/first error that occurred, if the step failed for any reason |
+| `additionalErrors` | array(error) | additional errors, if necessary |
 | `start` | integer | starting timestamp of the step (milliseconds elapsed since the epoch) |
 | `stop` | integer | ending timestamp of the step (milliseconds elapsed since the epoch) |
 

--- a/docs/reference/latest/results-file.md
+++ b/docs/reference/latest/results-file.md
@@ -41,6 +41,7 @@ Where steps contain the following keys:
 
 | name | type | description |
 | ---- | ---- | ----------- |
+| `id` | string | the step id |
 | `name` | string | the step name |
 | `outcome` | string | the overall outcome of the test, one of `passed`, `failed`, or `skipped` |
 | `error` | error | the primary/first error that occurred, if the step failed for any reason |

--- a/examples/00-intro.yaml
+++ b/examples/00-intro.yaml
@@ -103,3 +103,38 @@ tests:
 
       - exec: node1
         run: rm -f repeat-test-file
+
+  outputs:
+    name: Outputs test
+    outputs:
+      TEST_OUTPUT: ${{ steps['step-1'].outputs.A_VALUE }}
+    steps:
+      - id: step-1
+        exec: node1
+        run: |
+          echo '{ "a": 13 }'
+        outputs:
+          A_VALUE: ${{ fromJSON(step.stdout).a }}
+
+      - exec: node1
+        run: echo -n '13 is the same as ${{ steps['step-1'].outputs.A_VALUE }}'
+        expect:
+          # Can use outputs directly in expressions or interpolate them
+          - steps['step-1'].outputs.A_VALUE == '13'
+          - step.stdout == '13 is the same as 13'
+          # Return null for non-existent steps and keys
+          - null == steps['step-1'].outputs.NONEXISTENT_VALUE
+          - null == steps['nonexistent-step-id']
+
+  check-previous-outputs:
+    # repeat is an arbitrary example of a succesful test without 'outputs' defined
+    depends: [ outputs, repeat ]
+    name: Check previous tests' outputs
+    steps:
+      - exec: node1
+        run: echo -n 'Earlier job output was ${{ tests['outputs'].outputs.TEST_OUTPUT }}'
+        expect:
+          - step.stdout == 'Earlier job output was 13'
+          - tests['outputs'].outputs.TEST_OUTPUT == '13'
+          # tests always return an outputs mapping, even if they do not define them
+          - tests['repeat'].outputs == {}

--- a/examples/01-fails.yaml
+++ b/examples/01-fails.yaml
@@ -1,5 +1,9 @@
 name: Example Suite - Failures
 
+# This file demonstrates negative cases. Tests IDs prefixed 'fail-'
+# are expected to always fail. Test IDs prefixed 'maybe-' are expected
+# to pass (when using `--continue-on-error`).
+
 tests:
 
   fail-exit-code:
@@ -65,3 +69,44 @@ tests:
       - exec: node1
         run: /bin/true
         expect: throw("Intentional Failure")
+
+  fail-with-outputs:
+    name: Failing test that defines outputs
+    outputs:
+      TWO: 2
+      THREE: ${{ steps['failed-step'].outputs.THREE }}
+      ERROR: ${{ throw("Intentional Failure") }}
+    steps:
+      - id: failed-step
+        exec: node1
+        run: /bin/false
+        outputs:
+          THREE: ${{ 3 }}
+
+  maybe-check-empty-failure-outputs:
+    depends: fail-with-outputs
+    name: Assert failed tests still interpolate outputs
+    steps:
+      - exec: node1
+        run: /bin/true
+        expect:
+          # Successfully interpolated outputs are returned, even for failed tests
+          - tests['fail-with-outputs'].outputs.TWO == '2'
+          - tests['fail-with-outputs'].outputs.THREE == '3'
+          - tests['fail-with-outputs'].outputs.ERROR == null
+
+  fail-outputs-in-test-error:
+    name: Tests fail if test outputs error
+    outputs:
+      ERROR: ${{ throw("Intentional Failure") }}
+    steps:
+      - exec: node1
+        run: /bin/true
+
+  fail-outputs-in-step-error:
+    name: Tests fail if step outputs error
+    steps:
+      - exec: node1
+        run: /bin/true
+        outputs:
+          ERROR: ${{ throw("Intentional Failure") }}

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '2.4'
-
 services:
 
   node1:

--- a/schemas/input.yaml
+++ b/schemas/input.yaml
@@ -4,6 +4,10 @@ $defs:
     type: object
     propertyNames: { type: string }
     additionalProperties: { type: string, expression: InterpolatedText }
+  outputs:
+    type: object
+    propertyNames: { type: string }
+    additionalProperties: { type: string, expression: InterpolatedText }
 
 # suite
 type: object
@@ -23,6 +27,7 @@ properties:
       properties:
         env:  { "$ref": "#/$defs/env" }
         name: { type: string, expression: InterpolatedText }
+        outputs: { "$ref": "#/$defs/outputs" }
         depends:
           oneOf:
             - type: string
@@ -45,8 +50,10 @@ properties:
                   - { type: string, expression: Expression }
                   - { type: array, items: { type: string, expression: Expression } }
               name: { type: string, expression: InterpolatedText }
+              id: { type: string }
               if: { type: string, expression: Expression, default: "success()" }
               index: { type: integer }
+              outputs: { "$ref": "#/$defs/outputs" }
               run:
                 oneOf:
                   - { type: string, expression: InterpolatedText }

--- a/schemas/results-file.yaml
+++ b/schemas/results-file.yaml
@@ -35,6 +35,7 @@ properties:
         name: { type: string }
         outcome: { "$ref": "#/$defs/outcome" }
         error: { "$ref": "#/$defs/error" }
+        additionalErrors: { type: array, items: { "$ref": "#/$defs/error" } }
         start: { type: integer }
         stop: { type: integer }
         steps:
@@ -49,6 +50,7 @@ properties:
               name: { type: string }
               outcome: { "$ref": "#/$defs/outcome" }
               error: { "$ref": "#/$defs/error" }
+              additionalErrors: { type: array, items: { "$ref": "#/$defs/error" } }
               start: { type: integer }
               stop: { type: integer }
 

--- a/schemas/results-file.yaml
+++ b/schemas/results-file.yaml
@@ -47,6 +47,7 @@ properties:
             additionalProperties: false
             required: [ name, outcome, start, stop ]
             properties:
+              id: { type: string }
               name: { type: string }
               outcome: { "$ref": "#/$defs/outcome" }
               error: { "$ref": "#/$defs/error" }

--- a/src/dctest/core.cljs
+++ b/src/dctest/core.cljs
@@ -256,7 +256,7 @@ Options:
                           pass!)
           stop (js/Date.now)
           step (assoc step :start start :stop stop)]
-    (select-keys step [:outcome :name :start :stop :error])))
+    (select-keys step [:outcome :name :start :stop :error :additionalErrors])))
 
 (defn execute-steps
   "Runs all steps for a test. Returns test with completed steps.
@@ -308,7 +308,7 @@ Options:
           duration-in-sec (js/Math.floor (/ (- stop start) 1000))
           _ (log opts "    " (short-outcome test) (:name test) (str "(" duration-in-sec "s)"))]
 
-    (select-keys test [:id :name :outcome :start :stop :steps :error])))
+    (select-keys test [:id :name :outcome :start :stop :steps :error :additionalErrors])))
 
 (defn filter-tests [graph filter-str]
   (let [raw-list (if (= "*" filter-str)

--- a/src/dctest/expressions.cljs
+++ b/src/dctest/expressions.cljs
@@ -14,7 +14,7 @@
 (declare read-ast)
 
 (def supported-contexts
-  #{"env" "process" "step"})
+  #{"env" "process" "step" "steps" "tests"})
 
 (def stdlib
   ;; {name {:arity number :fn (fn [context & args] ..)}}

--- a/src/dctest/outcome.cljs
+++ b/src/dctest/outcome.cljs
@@ -9,6 +9,9 @@
 (defn passed? [{:keys [outcome]}]
   (= :passed outcome))
 
+(defn skipped? [{:keys [outcome]}]
+  (= :skipped outcome))
+
 (defn pending? [{:keys [outcome]}]
   (= :pending outcome))
 

--- a/src/dctest/outcome.cljs
+++ b/src/dctest/outcome.cljs
@@ -12,10 +12,14 @@
 (defn pending? [{:keys [outcome]}]
   (= :pending outcome))
 
-(defn fail! [m & [error]]
-  (merge m
-         {:outcome :failed}
-         (when error {:error error})))
+(defn fail! [m & errors]
+  (let [m (assoc m :outcome :failed)]
+    (reduce (fn append-error [res err]
+              (if-not (:error res)
+                (assoc res :error err)
+                (update res :additionalErrors (fnil conj []) err)))
+            m
+            errors)))
 
 (defn pass! [m] (assoc m :outcome :passed))
 (defn skip! [m] (assoc m :outcome :skipped))

--- a/test/runexamples
+++ b/test/runexamples
@@ -66,11 +66,11 @@ eopt="--environ-file ${repo_root}/examples/03-env-file"
 
 up
 
-check 5  0 "${copt}        " 00-intro.yaml
-check 6  7 "${copt}        " 00-intro.yaml 01-fails.yaml
-check 5  1 "               " 00-intro.yaml 01-fails.yaml
-check 12 0 "${copt}        " 02-deps.yaml
-check 4  0 "${copt} ${eopt}" 03-env.yaml
-check 2  2 "${copt}        " 03-env.yaml
+check 7  0  "${copt}        " 00-intro.yaml
+check 9  10 "${copt}        " 00-intro.yaml 01-fails.yaml
+check 7  1  "               " 00-intro.yaml 01-fails.yaml
+check 12 0  "${copt}        " 02-deps.yaml
+check 4  0  "${copt} ${eopt}" 03-env.yaml
+check 2  2  "${copt}        " 03-env.yaml
 
 down


### PR DESCRIPTION
This PR builds off of https://github.com/Viasat/dctest/pull/22 (to maintain the `./test/runexamples` counts).  Only the last commit is new.

In short, test/step 'outputs' work like [GHA's job-level 'outputs'](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs).  I chose not to implement something analogous to GHA's `GITHUB_OUTPUT`.  Instead we use the same mechanism for both tests and steps.

The goal of outputs is to decrease the pain around comparing values within a test (start value vs. end value, or value in one container vs. value in another container) and around capturing/naming computed values to use later (either from earlier step or earlier test).

The new expression contexts are called 'tests' (not 'needs' or 'depends') and 'steps'.  I chose to not attempt to check that user-defined expressions that reference the 'tests' context actually refer to a test id in their 'depends' graph (either the immediately named shallow graph or the full resolved graph).  Open to discussion here.  Right now the user will get a null value if they reference something that doesn't exist, and it's up to them to ensure the right test is depended upon and runs first.

The implementation of this feature is not fantastic, but I think it's really just exposing that the previous `pending->`/related work is still not right.  I've been working on refactoring this into a form that, instead of interpolating tests and steps "in place" in `execute-step` and `run-test`, creates a new binding for the interpolated result and leaves the user's input test or step untouched.  I think I'm getting closer, but it has held up the PR for this feature for a couple weeks now.  If it is ok, I propose reviewing the 'outputs' feature on its own and that it doesn't make this code significantly worse, and I will continue to explore better ways to interpolate things while handling exceptions etc.